### PR TITLE
fix: resolve launch and backup decryption issues on Windows

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,11 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "openextract-dev",
+      "runtimeExecutable": "cmd",
+      "runtimeArgs": ["/c", "npm run dev"],
+      "port": 5174
+    }
+  ]
+}

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -1,3 +1,4 @@
+export {};
 const { app, BrowserWindow, ipcMain, dialog } = require('electron');
 const path = require('path');
 const { PythonSidecar } = require('./sidecar');
@@ -22,7 +23,7 @@ function createWindow() {
   });
 
   if (isDev) {
-    mainWindow.loadURL('http://localhost:5173');
+    mainWindow.loadURL('http://localhost:5174');
     mainWindow.webContents.openDevTools();
   } else {
     mainWindow.loadFile(path.join(__dirname, '..', 'dist', 'index.html'));
@@ -31,10 +32,10 @@ function createWindow() {
 
 function getPythonPath(): string {
   if (isDev) {
-    return 'python3';
+    return process.platform === 'win32' ? 'python' : 'python3';
   }
   // In production, use the bundled PyInstaller executable
-  const resourcePath = process.resourcesPath || '';
+  const resourcePath = (process as any).resourcesPath || '';
   const binaryName = process.platform === 'win32' ? 'openextract-engine.exe' : 'openextract-engine';
   return path.join(resourcePath, 'python', binaryName);
 }

--- a/electron/sidecar.ts
+++ b/electron/sidecar.ts
@@ -1,3 +1,4 @@
+export {};
 const { spawn } = require('child_process');
 
 interface PendingRequest {

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline';" />
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline';" />
     <title>OpenExtract</title>
   </head>
   <body class="bg-gray-50 dark:bg-gray-900">

--- a/package.json
+++ b/package.json
@@ -2,11 +2,11 @@
   "name": "openextract",
   "version": "0.1.0",
   "description": "Free, open-source iPhone backup extractor",
-  "main": "electron/main.js",
+  "main": "dist-electron/main.js",
   "author": "OpenExtract Contributors",
   "license": "MIT",
   "scripts": {
-    "dev": "concurrently \"vite\" \"wait-on http://localhost:5173 && electron .\"",
+    "dev": "concurrently \"vite\" \"wait-on http://localhost:5174 && electron .\"",
     "build:renderer": "vite build",
     "build:electron": "tsc -p tsconfig.electron.json",
     "build": "npm run build:renderer && npm run build:electron",
@@ -41,7 +41,7 @@
     },
     "files": [
       "dist/**/*",
-      "electron/**/*.js",
+      "dist-electron/**/*.js",
       "python/dist/**/*"
     ],
     "extraResources": [

--- a/python/backup.py
+++ b/python/backup.py
@@ -151,10 +151,12 @@ class BackupManager:
             home = Path.home()
             dirs.append(str(home / "Library" / "Application Support" / "MobileSync" / "Backup"))
         elif sys.platform == "win32":
+            home = Path.home()
+            # Newer Apple Devices app stores backups directly in user home
+            dirs.append(str(home / "Apple" / "MobileSync" / "Backup"))
             appdata = os.environ.get("APPDATA", "")
             if appdata:
                 dirs.append(os.path.join(appdata, "Apple Computer", "MobileSync", "Backup"))
-                # Also check the newer "Apple" path
                 dirs.append(os.path.join(appdata, "Apple", "MobileSync", "Backup"))
         else:
             # Linux - user might have copied a backup here
@@ -256,15 +258,22 @@ class BackupManager:
 
         return info
 
-    def open_backup(self, udid: str, password: Optional[str] = None) -> dict:
+    def open_backup(self, udid: str, password: Optional[str] = None,
+                    backup_dir: Optional[str] = None) -> dict:
         """Open a backup for reading. Decrypts if encrypted and password provided."""
-        # Find the backup directory
-        all_backups = self.list_backups()
         backup_info = None
-        for b in all_backups["backups"]:
-            if b["udid"] == udid:
-                backup_info = b
-                break
+
+        # Use provided backup_dir directly if given
+        if backup_dir and os.path.isdir(backup_dir):
+            backup_info = self._read_backup_info(backup_dir)
+
+        # Fall back to scanning default locations
+        if not backup_info:
+            all_backups = self.list_backups()
+            for b in all_backups["backups"]:
+                if b["udid"] == udid:
+                    backup_info = b
+                    break
 
         if not backup_info:
             raise ValueError(f"Backup not found: {udid}")

--- a/python/main.py
+++ b/python/main.py
@@ -59,7 +59,8 @@ class SidecarServer:
     def open_backup(self, params):
         udid = params["udid"]
         password = params.get("password")
-        return self.backup_manager.open_backup(udid, password=password)
+        backup_dir = params.get("backup_dir")
+        return self.backup_manager.open_backup(udid, password=password, backup_dir=backup_dir)
 
     def validate_password(self, params):
         udid = params["udid"]

--- a/src/components/BackupSelector.tsx
+++ b/src/components/BackupSelector.tsx
@@ -8,13 +8,13 @@ interface Props {
   loading: boolean;
   error: string | null;
   onRefresh: (path?: string) => Promise<void>;
-  onOpen: (udid: string, password?: string) => Promise<string>;
+  onOpen: (udid: string, password?: string, backupDir?: string) => Promise<string>;
 }
 
 export default function BackupSelector({ backups, loading, error, onRefresh, onOpen }: Props) {
   const [password, setPassword] = useState('');
   const [showPassword, setShowPassword] = useState(false);
-  const [pendingUdid, setPendingUdid] = useState<string | null>(null);
+  const [pendingBackup, setPendingBackup] = useState<BackupInfo | null>(null);
   const [openError, setOpenError] = useState<string | null>(null);
 
   useEffect(() => {
@@ -24,9 +24,9 @@ export default function BackupSelector({ backups, loading, error, onRefresh, onO
   const handleOpen = async (backup: BackupInfo) => {
     setOpenError(null);
     if (backup.encrypted) {
-      setPendingUdid(backup.udid);
+      setPendingBackup(backup);
     } else {
-      const status = await onOpen(backup.udid);
+      const status = await onOpen(backup.udid, undefined, backup.backup_dir);
       if (status === 'error') {
         setOpenError('Failed to open backup');
       }
@@ -34,13 +34,13 @@ export default function BackupSelector({ backups, loading, error, onRefresh, onO
   };
 
   const handlePasswordSubmit = async () => {
-    if (!pendingUdid || !password) return;
+    if (!pendingBackup || !password) return;
     setOpenError(null);
-    const status = await onOpen(pendingUdid, password);
+    const status = await onOpen(pendingBackup.udid, password, pendingBackup.backup_dir);
     if (status === 'error') {
       setOpenError('Incorrect password or corrupted backup');
     } else if (status === 'open') {
-      setPendingUdid(null);
+      setPendingBackup(null);
       setPassword('');
     }
   };
@@ -73,7 +73,7 @@ export default function BackupSelector({ backups, loading, error, onRefresh, onO
         )}
 
         {/* Password prompt modal */}
-        {pendingUdid && (
+        {pendingBackup && (
           <div className="mb-6 p-4 bg-blue-50 border border-blue-200 rounded-lg">
             <p className="text-sm font-medium text-blue-800 mb-3">
               This backup is encrypted. Enter your backup password:
@@ -104,7 +104,7 @@ export default function BackupSelector({ backups, loading, error, onRefresh, onO
                 {loading ? 'Decrypting...' : 'Unlock'}
               </button>
               <button
-                onClick={() => { setPendingUdid(null); setPassword(''); }}
+                onClick={() => { setPendingBackup(null); setPassword(''); }}
                 className="px-3 py-2 text-gray-600 text-sm hover:text-gray-800"
               >
                 Cancel

--- a/src/hooks/useBackup.ts
+++ b/src/hooks/useBackup.ts
@@ -33,13 +33,13 @@ export function useBackup() {
     }
   }, []);
 
-  const openBackup = useCallback(async (udid: string, password?: string) => {
+  const openBackup = useCallback(async (udid: string, password?: string, backupDir?: string) => {
     setLoading(true);
     setError(null);
     try {
       const result = await sidecarCall<{ status: string; info: BackupInfo }>(
         'open_backup',
-        { udid, password }
+        { udid, password, backup_dir: backupDir }
       );
       if (result.status === 'password_required') {
         return 'password_required';

--- a/tsconfig.electron.json
+++ b/tsconfig.electron.json
@@ -3,7 +3,7 @@
     "target": "ES2020",
     "module": "commonjs",
     "lib": ["ES2020"],
-    "outDir": "electron",
+    "outDir": "dist-electron",
     "rootDir": "electron",
     "strict": true,
     "esModuleInterop": true,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -14,6 +14,6 @@ export default defineConfig({
     outDir: 'dist',
   },
   server: {
-    port: 5173,
+    port: 5174,
   },
 });


### PR DESCRIPTION
## Summary

- **Build fix**: `tsconfig.electron.json` had `outDir: "electron"` matching the source dir, causing TypeScript to exclude all inputs. Changed to `dist-electron/` and updated `package.json` `main` entry.
- **Windows compatibility**: Use `python` (not `python3`) on win32 in dev mode; add `~/Apple/MobileSync/Backup` as a default backup search path (used by the Apple Devices app).
- **Backup decryption fix**: `open_backup` was re-scanning default locations to find the backup, failing for backups found via custom paths. Now passes `backup_dir` directly through the IPC stack.
- **Dev environment**: Move Vite port to 5174 to avoid conflicts, relax CSP to allow Vite HMR inline scripts, add `.claude/launch.json` for preview server.
- **TypeScript module scope**: Added `export {}` to `electron/main.ts` and `electron/sidecar.ts` to prevent redeclaration errors.

## Test plan

- [x] `npm run build:electron` compiles without errors
- [x] `npm run dev` launches Electron window with Vite renderer
- [x] Backup at `~/Apple/MobileSync/Backup` is discovered automatically
- [x] Encrypted backup can be unlocked with password (no "Backup not found" error)
- [x] Messages load correctly after unlock

🤖 Generated with [Claude Code](https://claude.com/claude-code)