### PR TITLE
feat: Messages export, in-conversation search, and date range filtering

### DIFF
--- a/python/main.py
+++ b/python/main.py
@@ -83,9 +83,13 @@ class SidecarServer:
         chat_id = params["chat_id"]
         offset = params.get("offset", 0)
         limit = params.get("limit", 100)
+        date_from = params.get("date_from")
+        date_to = params.get("date_to")
         backup = self.backup_manager.get_open_backup(udid)
         contacts = self.contact_resolver.load_contacts(backup)
-        return self.message_extractor.get_messages(backup, chat_id, contacts, offset, limit)
+        return self.message_extractor.get_messages(
+            backup, chat_id, contacts, offset, limit, date_from, date_to
+        )
 
     def get_attachment(self, params):
         udid = params["udid"]
@@ -97,9 +101,13 @@ class SidecarServer:
         udid = params["udid"]
         query = params["query"]
         chat_id = params.get("chat_id")
+        date_from = params.get("date_from")
+        date_to = params.get("date_to")
         backup = self.backup_manager.get_open_backup(udid)
         contacts = self.contact_resolver.load_contacts(backup)
-        return self.message_extractor.search_messages(backup, query, contacts, chat_id)
+        return self.message_extractor.search_messages(
+            backup, query, contacts, chat_id, date_from=date_from, date_to=date_to
+        )
 
     def list_albums(self, params):
         udid = params["udid"]
@@ -166,12 +174,16 @@ class SidecarServer:
     def export_conversation(self, params):
         udid = params["udid"]
         chat_id = params["chat_id"]
-        fmt = params.get("format", "pdf")
+        fmt = params.get("format", "txt")
         output_dir = params.get("output_dir", ".")
+        date_from = params.get("date_from")
+        date_to = params.get("date_to")
+        query = params.get("query")
         backup = self.backup_manager.get_open_backup(udid)
         contacts = self.contact_resolver.load_contacts(backup)
         return self.message_extractor.export_conversation(
-            backup, chat_id, contacts, fmt, output_dir
+            backup, chat_id, contacts, fmt, output_dir,
+            date_from=date_from, date_to=date_to, query=query
         )
 
     def export_photos(self, params):

--- a/python/messages.py
+++ b/python/messages.py
@@ -266,6 +266,37 @@ def apple_date_to_iso(apple_timestamp) -> Optional[str]:
         return None
 
 
+def iso_to_apple_date(iso_str: str, nanoseconds: bool = False) -> Optional[float]:
+    """Convert ISO 8601 string to Apple Cocoa epoch timestamp.
+
+    Pass nanoseconds=True when the target DB stores timestamps as nanoseconds
+    (iOS 14+), which is detected by sampling a row before calling this.
+    """
+    if not iso_str:
+        return None
+    try:
+        from datetime import timezone
+        # Accept date-only strings like "2023-01-01"
+        if len(iso_str) == 10:
+            iso_str += "T00:00:00"
+        dt = datetime.fromisoformat(iso_str)
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        delta = dt - APPLE_EPOCH.replace(tzinfo=timezone.utc)
+        seconds = delta.total_seconds()
+        return seconds * 1_000_000_000 if nanoseconds else seconds
+    except (ValueError, TypeError):
+        return None
+
+
+def _db_uses_nanoseconds(conn) -> bool:
+    """Return True if the message table stores timestamps in nanoseconds (iOS 14+)."""
+    row = conn.execute("SELECT date FROM message WHERE date > 0 LIMIT 1").fetchone()
+    if row and row[0] is not None:
+        return float(row[0]) > NANOSECOND_THRESHOLD
+    return False
+
+
 class MessageExtractor:
     """Extracts messages and conversations from iOS sms.db."""
 
@@ -329,7 +360,9 @@ class MessageExtractor:
         return {"conversations": conversations}
 
     def get_messages(self, backup, chat_id: int, contacts: dict,
-                     offset: int = 0, limit: int = 100) -> dict:
+                     offset: int = 0, limit: int = 100,
+                     date_from: Optional[str] = None,
+                     date_to: Optional[str] = None) -> dict:
         """Get paginated messages from a conversation."""
         db_path = self._get_sms_db(backup)
         if not db_path:
@@ -373,15 +406,29 @@ class MessageExtractor:
             if has_share_direction:   select_parts.append('m.share_direction')
             if has_uncanonicalized:   select_parts.append('h.uncanonicalized_id')
 
+            date_clauses = []
+            date_params: list = [chat_id]
+            if date_from or date_to:
+                ns = _db_uses_nanoseconds(conn)
+                apple_from = iso_to_apple_date(date_from, nanoseconds=ns) if date_from else None
+                apple_to = iso_to_apple_date(date_to, nanoseconds=ns) if date_to else None
+                if apple_from is not None:
+                    date_clauses.append("m.date >= ?")
+                    date_params.append(apple_from)
+                if apple_to is not None:
+                    date_clauses.append("m.date <= ?")
+                    date_params.append(apple_to)
+            where_extra = (" AND " + " AND ".join(date_clauses)) if date_clauses else ""
+
             rows = conn.execute(f"""
                 SELECT {', '.join(select_parts)}
                 FROM message m
                 LEFT JOIN handle h ON h.ROWID = m.handle_id
                 INNER JOIN chat_message_join cmj ON cmj.message_id = m.ROWID
-                WHERE cmj.chat_id = ?
+                WHERE cmj.chat_id = ?{where_extra}
                 ORDER BY m.date DESC
                 LIMIT ? OFFSET ?
-            """, (chat_id, limit, offset)).fetchall()
+            """, (*date_params, limit, offset)).fetchall()
 
             # Reverse so messages render top-to-bottom in chronological order
             rows = list(rows)[::-1]
@@ -493,10 +540,12 @@ class MessageExtractor:
 
                 messages.append(msg)
 
-            # Get total count
+            # Get total count (respects date filters)
             total = conn.execute(
-                "SELECT COUNT(*) FROM chat_message_join WHERE chat_id = ?",
-                (chat_id,)
+                f"""SELECT COUNT(*) FROM message m
+                    INNER JOIN chat_message_join cmj ON cmj.message_id = m.ROWID
+                    WHERE cmj.chat_id = ?{where_extra}""",
+                tuple(date_params)
             ).fetchone()[0]
 
         finally:
@@ -611,8 +660,11 @@ class MessageExtractor:
             conn.close()
 
     def search_messages(self, backup, query: str, contacts: dict,
-                        chat_id: Optional[int] = None) -> dict:
-        """Search messages by text content."""
+                        chat_id: Optional[int] = None,
+                        date_from: Optional[str] = None,
+                        date_to: Optional[str] = None,
+                        limit: int = 500) -> dict:
+        """Search messages by text content, optionally filtered by chat and date range."""
         db_path = self._get_sms_db(backup)
         if not db_path:
             return {"results": []}
@@ -635,13 +687,24 @@ class MessageExtractor:
                 INNER JOIN chat_message_join cmj ON cmj.message_id = m.ROWID
                 WHERE m.text LIKE ?
             """
-            params = [f"%{query}%"]
+            params: list = [f"%{query}%"]
 
             if chat_id:
                 sql += " AND cmj.chat_id = ?"
                 params.append(chat_id)
 
-            sql += " ORDER BY m.date DESC LIMIT 50"
+            if date_from or date_to:
+                ns = _db_uses_nanoseconds(conn)
+                apple_from = iso_to_apple_date(date_from, nanoseconds=ns) if date_from else None
+                apple_to = iso_to_apple_date(date_to, nanoseconds=ns) if date_to else None
+                if apple_from is not None:
+                    sql += " AND m.date >= ?"
+                    params.append(apple_from)
+                if apple_to is not None:
+                    sql += " AND m.date <= ?"
+                    params.append(apple_to)
+
+            sql += f" ORDER BY m.date ASC LIMIT {int(limit)}"
 
             rows = conn.execute(sql, params).fetchall()
             for row in rows:
@@ -660,17 +723,31 @@ class MessageExtractor:
         return {"results": results, "query": query}
 
     def export_conversation(self, backup, chat_id: int, contacts: dict,
-                            fmt: str, output_dir: str) -> dict:
-        """Export a conversation to the specified format."""
-        # Get all messages (no pagination for export)
-        all_messages = []
-        offset = 0
-        while True:
-            batch = self.get_messages(backup, chat_id, contacts, offset, 500)
-            all_messages.extend(batch["messages"])
-            if offset + 500 >= batch["total"]:
-                break
-            offset += 500
+                            fmt: str, output_dir: str,
+                            date_from: Optional[str] = None,
+                            date_to: Optional[str] = None,
+                            query: Optional[str] = None) -> dict:
+        """Export a conversation to the specified format, with optional date/search filters."""
+        if query:
+            # Search-filtered export — fetch matching messages directly
+            result = self.search_messages(
+                backup, query, contacts, chat_id,
+                date_from=date_from, date_to=date_to, limit=100000
+            )
+            all_messages = result["results"]
+        else:
+            # Date-range or full export via paginated get_messages
+            all_messages = []
+            offset = 0
+            while True:
+                batch = self.get_messages(
+                    backup, chat_id, contacts, offset, 500,
+                    date_from=date_from, date_to=date_to
+                )
+                all_messages.extend(batch["messages"])
+                if offset + 500 >= batch["total"]:
+                    break
+                offset += 500
 
         if fmt == "txt":
             return self._export_txt(all_messages, chat_id, output_dir)
@@ -681,14 +758,44 @@ class MessageExtractor:
         else:
             return {"error": f"Unsupported format: {fmt}"}
 
+    def _attachment_label(self, msg) -> str:
+        """Return a clean text label for a message's attachments."""
+        attachments = msg.get("attachments") or []
+        if not attachments:
+            return "[Attachment]"
+        parts = []
+        for a in attachments:
+            name = a.get("transfer_name") or a.get("filename") or ""
+            mime = a.get("mime_type") or ""
+            if mime.startswith("image/"):
+                kind = "Image"
+            elif mime.startswith("video/"):
+                kind = "Video"
+            elif mime.startswith("audio/"):
+                kind = "Audio"
+            else:
+                kind = "File"
+            label = f"[{kind}: {name}]" if name else f"[{kind}]"
+            parts.append(label)
+        return " ".join(parts)
+
+    def _message_text(self, msg) -> str:
+        """Return the display text for a message, replacing binary attachment data with labels."""
+        if msg.get("has_attachments"):
+            label = self._attachment_label(msg)
+            # Append any real accompanying text (e.g. a caption sent with an image)
+            text = (msg.get("text") or "").strip()
+            return f"{text} {label}".strip() if text else label
+        return msg.get("text") or ""
+
     def _export_txt(self, messages, chat_id, output_dir):
         filename = f"conversation_{chat_id}.txt"
         filepath = os.path.join(output_dir, filename)
-        with open(filepath, "w", encoding="utf-8") as f:
+        with open(filepath, "w", encoding="utf-8-sig") as f:
             for msg in messages:
                 date = msg["date"] or "Unknown date"
                 sender = msg["sender"]
-                text = msg["text"] or "[Attachment]"
+                text = self._message_text(msg) or "[No content]"
                 f.write(f"[{date}] {sender}: {text}\n")
         return {"file": filepath, "message_count": len(messages)}
 
@@ -696,12 +803,12 @@ class MessageExtractor:
         import csv
         filename = f"conversation_{chat_id}.csv"
         filepath = os.path.join(output_dir, filename)
-        with open(filepath, "w", newline="", encoding="utf-8") as f:
+        with open(filepath, "w", newline="", encoding="utf-8-sig") as f:
             writer = csv.writer(f)
             writer.writerow(["Date", "Sender", "Text", "Is From Me", "Has Attachments"])
             for msg in messages:
                 writer.writerow([
-                    msg["date"], msg["sender"], msg["text"],
+                    msg["date"], msg["sender"], self._message_text(msg),
                     msg["is_from_me"], msg["has_attachments"]
                 ])
         return {"file": filepath, "message_count": len(messages)}

--- a/src/components/MessageView.tsx
+++ b/src/components/MessageView.tsx
@@ -1,10 +1,38 @@
-import { useEffect, useState, useRef } from 'react';
-import { useMessages, Conversation, Message } from '../hooks/useMessages';
-import { formatRelative, formatDateTime } from '../lib/dates';
+import { useEffect, useState, useRef, useCallback } from 'react';
+import { useMessages } from '../hooks/useMessages';
+import { formatRelative } from '../lib/dates';
+import { saveFolder } from '../lib/ipc';
 import ChatBubble from './ChatBubble';
 
 interface Props {
   udid: string;
+}
+
+// Returns today / N-months-ago as YYYY-MM-DD strings (in local time)
+function datePreset(months: number | null): { from: string; to: string } {
+  const to = new Date();
+  const from = new Date();
+  if (months !== null) from.setMonth(from.getMonth() - months);
+  const fmt = (d: Date) =>
+    `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
+  return { from: months === null ? '' : fmt(from), to: fmt(to) };
+}
+
+function thisYearPreset(): { from: string; to: string } {
+  const year = new Date().getFullYear();
+  return { from: `${year}-01-01`, to: `${year}-12-31` };
+}
+
+/**
+ * Convert a YYYY-MM-DD date string to a UTC ISO string using local midnight.
+ * This ensures "March 1" means March 1 in the user's timezone, not UTC midnight.
+ */
+function localDateToISO(dateStr: string, endOfDay = false): string {
+  const [year, month, day] = dateStr.split('-').map(Number);
+  const d = endOfDay
+    ? new Date(year, month - 1, day, 23, 59, 59)
+    : new Date(year, month - 1, day, 0, 0, 0);
+  return d.toISOString();
 }
 
 export default function MessageView({ udid }: Props) {
@@ -16,27 +44,96 @@ export default function MessageView({ udid }: Props) {
     loading,
     loadConversations,
     loadMessages,
+    searchMessages,
+    exportConversation,
   } = useMessages(udid);
 
-  const [searchQuery, setSearchQuery] = useState('');
+  // Conversation list search
+  const [convSearch, setConvSearch] = useState('');
+
+  // In-conversation filters
+  const [msgSearch, setMsgSearch] = useState('');
+  const [dateFrom, setDateFrom] = useState('');
+  const [dateTo, setDateTo] = useState('');
+  const [filtersActive, setFiltersActive] = useState(false);
+
+  // Export
+  const [exportFormat, setExportFormat] = useState<'txt' | 'csv' | 'html'>('txt');
+  const [exporting, setExporting] = useState(false);
+
   const messagesEndRef = useRef<HTMLDivElement>(null);
 
-  useEffect(() => {
-    loadConversations();
-  }, [loadConversations]);
+  useEffect(() => { loadConversations(); }, [loadConversations]);
 
   useEffect(() => {
-    // Scroll to bottom when messages load
     messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
   }, [messages]);
 
-  const filteredConversations = searchQuery
+  // Apply filters (debounced via a button or on Enter; date fields apply immediately)
+  const applyFilters = useCallback((query: string, from: string, to: string) => {
+    if (!activeChat) return;
+    const hasQuery = query.trim().length > 0;
+    const hasDate = from || to;
+    // Convert local date strings to UTC ISO so the backend compares in the user's timezone
+    const utcFrom = from ? localDateToISO(from, false) : undefined;
+    const utcTo = to ? localDateToISO(to, true) : undefined;
+    if (hasQuery || hasDate) {
+      setFiltersActive(true);
+      if (hasQuery) {
+        searchMessages(query.trim(), activeChat, utcFrom, utcTo);
+      } else {
+        // Date-only filter: use loadMessages with date params
+        loadMessages(activeChat, 0, 500, utcFrom, utcTo);
+      }
+    } else {
+      setFiltersActive(false);
+      loadMessages(activeChat);
+    }
+  }, [activeChat, searchMessages, loadMessages]);
+
+  function handleClearFilters() {
+    setMsgSearch('');
+    setDateFrom('');
+    setDateTo('');
+    setFiltersActive(false);
+    if (activeChat) loadMessages(activeChat);
+  }
+
+  function applyPreset(from: string, to: string) {
+    setDateFrom(from);
+    setDateTo(to);
+    applyFilters(msgSearch, from, to);
+  }
+
+  async function handleExport() {
+    if (!activeChat) return;
+    const dir = await saveFolder();
+    if (!dir) return;
+    setExporting(true);
+    try {
+      const result = await exportConversation(
+        activeChat, exportFormat, dir,
+        dateFrom ? localDateToISO(dateFrom, false) : undefined,
+        dateTo ? localDateToISO(dateTo, true) : undefined,
+        msgSearch.trim() || undefined
+      );
+      if (result) {
+        alert(`Exported ${result.message_count} messages to:\n${result.file}`);
+      }
+    } catch (err: any) {
+      alert(`Export failed: ${err.message}`);
+    } finally {
+      setExporting(false);
+    }
+  }
+
+  const filteredConversations = convSearch
     ? conversations.filter(
-      (c) =>
-        c.display_name.toLowerCase().includes(searchQuery.toLowerCase()) ||
-        c.chat_identifier.toLowerCase().includes(searchQuery.toLowerCase()) ||
-        c.last_message_preview.toLowerCase().includes(searchQuery.toLowerCase())
-    )
+        (c) =>
+          c.display_name.toLowerCase().includes(convSearch.toLowerCase()) ||
+          c.chat_identifier.toLowerCase().includes(convSearch.toLowerCase()) ||
+          c.last_message_preview.toLowerCase().includes(convSearch.toLowerCase())
+      )
     : conversations;
 
   const activeConversation = conversations.find((c) => c.chat_id === activeChat);
@@ -49,8 +146,8 @@ export default function MessageView({ udid }: Props) {
           <input
             type="text"
             placeholder="Search conversations..."
-            value={searchQuery}
-            onChange={(e) => setSearchQuery(e.target.value)}
+            value={convSearch}
+            onChange={(e) => setConvSearch(e.target.value)}
             className="w-full px-3 py-2 bg-gray-100 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
           />
         </div>
@@ -61,9 +158,13 @@ export default function MessageView({ udid }: Props) {
           {filteredConversations.map((conv) => (
             <button
               key={conv.chat_id}
-              onClick={() => loadMessages(conv.chat_id)}
-              className={`w-full text-left px-4 py-3 border-b border-gray-50 hover:bg-gray-50 transition-colors ${activeChat === conv.chat_id ? 'bg-blue-50' : ''
-                }`}
+              onClick={() => {
+                handleClearFilters();
+                loadMessages(conv.chat_id);
+              }}
+              className={`w-full text-left px-4 py-3 border-b border-gray-50 hover:bg-gray-50 transition-colors ${
+                activeChat === conv.chat_id ? 'bg-blue-50' : ''
+              }`}
             >
               <div className="flex justify-between items-start">
                 <div className="font-medium text-sm text-gray-900 truncate flex-1">
@@ -91,28 +192,127 @@ export default function MessageView({ udid }: Props) {
       </div>
 
       {/* Message display */}
-      <div className="flex-1 flex flex-col bg-white">
+      <div className="flex-1 flex flex-col bg-white min-w-0">
         {activeConversation ? (
           <>
             {/* Chat header */}
             <div className="px-4 py-3 border-b border-gray-200 flex items-center justify-between flex-shrink-0">
               <div>
-                <div className="font-medium text-gray-900">
-                  {activeConversation.display_name}
-                </div>
+                <div className="font-medium text-gray-900">{activeConversation.display_name}</div>
                 <div className="text-xs text-gray-500">
-                  {activeConversation.chat_identifier} · {totalMessages} messages
+                  {activeConversation.chat_identifier} · {totalMessages} {filtersActive ? 'matching' : ''} messages
                 </div>
               </div>
-              <button className="text-sm text-blue-600 hover:text-blue-800">
-                Export
-              </button>
+              <div className="flex items-center gap-2">
+                <select
+                  value={exportFormat}
+                  onChange={(e) => setExportFormat(e.target.value as 'txt' | 'csv' | 'html')}
+                  className="text-sm border border-gray-200 rounded px-2 py-1 text-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                >
+                  <option value="txt">TXT</option>
+                  <option value="csv">CSV</option>
+                  <option value="html">HTML</option>
+                </select>
+                <button
+                  onClick={handleExport}
+                  disabled={exporting}
+                  className="text-sm text-blue-600 hover:text-blue-800 disabled:opacity-50"
+                >
+                  {exporting ? 'Exporting...' : filtersActive ? 'Export filtered' : 'Export'}
+                </button>
+              </div>
+            </div>
+
+            {/* Filter bar */}
+            <div className="px-4 py-2 border-b border-gray-100 bg-gray-50 flex-shrink-0 space-y-2">
+              {/* Search row */}
+              <div className="flex gap-2">
+                <input
+                  type="text"
+                  placeholder="Search in conversation..."
+                  value={msgSearch}
+                  onChange={(e) => setMsgSearch(e.target.value)}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter') applyFilters(msgSearch, dateFrom, dateTo);
+                  }}
+                  className="flex-1 px-3 py-1.5 text-sm bg-white border border-gray-200 rounded focus:outline-none focus:ring-2 focus:ring-blue-500"
+                />
+                <button
+                  onClick={() => applyFilters(msgSearch, dateFrom, dateTo)}
+                  className="px-3 py-1.5 text-sm bg-blue-600 text-white rounded hover:bg-blue-700"
+                >
+                  Search
+                </button>
+                {filtersActive && (
+                  <button
+                    onClick={handleClearFilters}
+                    className="px-3 py-1.5 text-sm text-gray-500 hover:text-gray-700 border border-gray-200 rounded bg-white"
+                  >
+                    Clear
+                  </button>
+                )}
+              </div>
+
+              {/* Date filter row */}
+              <div className="flex items-center gap-2 flex-wrap">
+                {/* Preset buttons */}
+                <span className="text-xs text-gray-400">Date:</span>
+                {[
+                  { label: '3 months', months: 3 },
+                  { label: '6 months', months: 6 },
+                  { label: '1 year', months: 12 },
+                  { label: 'This year', months: null },
+                  { label: 'All time', months: -1 },
+                ].map(({ label, months }) => (
+                  <button
+                    key={label}
+                    onClick={() => {
+                      if (months === -1) {
+                        applyPreset('', '');
+                      } else if (months === null) {
+                        const p = thisYearPreset();
+                        applyPreset(p.from, p.to);
+                      } else {
+                        const p = datePreset(months);
+                        applyPreset(p.from, p.to);
+                      }
+                    }}
+                    className="text-xs px-2 py-1 rounded border border-gray-200 bg-white hover:bg-gray-100 text-gray-600"
+                  >
+                    {label}
+                  </button>
+                ))}
+
+                {/* Custom date inputs */}
+                <input
+                  type="date"
+                  value={dateFrom}
+                  onChange={(e) => {
+                    setDateFrom(e.target.value);
+                    applyFilters(msgSearch, e.target.value, dateTo);
+                  }}
+                  className="text-xs px-2 py-1 border border-gray-200 rounded bg-white text-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                />
+                <span className="text-xs text-gray-400">to</span>
+                <input
+                  type="date"
+                  value={dateTo}
+                  onChange={(e) => {
+                    setDateTo(e.target.value);
+                    applyFilters(msgSearch, dateFrom, e.target.value);
+                  }}
+                  className="text-xs px-2 py-1 border border-gray-200 rounded bg-white text-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                />
+              </div>
             </div>
 
             {/* Messages area */}
             <div className="flex-1 overflow-y-auto px-4 py-4 bg-gray-50">
-              {loading && messages.length === 0 && (
-                <div className="text-center text-gray-500 text-sm py-8">Loading messages...</div>
+              {loading && (
+                <div className="text-center text-gray-500 text-sm py-8">Loading...</div>
+              )}
+              {!loading && messages.length === 0 && filtersActive && (
+                <div className="text-center text-gray-400 text-sm py-8">No messages match the current filters.</div>
               )}
               <div className="space-y-1">
                 {messages.map((msg) => (

--- a/src/hooks/useMessages.ts
+++ b/src/hooks/useMessages.ts
@@ -62,14 +62,20 @@ export function useMessages(udid: string | undefined) {
     }
   }, [udid]);
 
-  const loadMessages = useCallback(async (chatId: number, offset = 0, limit = 100) => {
+  const loadMessages = useCallback(async (
+    chatId: number,
+    offset = 0,
+    limit = 100,
+    dateFrom?: string,
+    dateTo?: string
+  ) => {
     if (!udid) return;
     setLoading(true);
     setActiveChat(chatId);
     try {
       const result = await sidecarCall<{ messages: Message[]; total: number }>(
         'get_messages',
-        { udid, chat_id: chatId, offset, limit }
+        { udid, chat_id: chatId, offset, limit, date_from: dateFrom, date_to: dateTo }
       );
       if (offset === 0) {
         setMessages(result.messages);
@@ -82,13 +88,40 @@ export function useMessages(udid: string | undefined) {
     }
   }, [udid]);
 
-  const searchMessages = useCallback(async (query: string, chatId?: number) => {
+  const searchMessages = useCallback(async (
+    query: string,
+    chatId?: number,
+    dateFrom?: string,
+    dateTo?: string
+  ) => {
     if (!udid) return [];
-    const result = await sidecarCall<{ results: Message[] }>(
-      'search_messages',
-      { udid, query, chat_id: chatId }
+    setLoading(true);
+    try {
+      const result = await sidecarCall<{ results: Message[] }>(
+        'search_messages',
+        { udid, query, chat_id: chatId, date_from: dateFrom, date_to: dateTo }
+      );
+      setMessages(result.results);
+      setTotalMessages(result.results.length);
+      return result.results;
+    } finally {
+      setLoading(false);
+    }
+  }, [udid]);
+
+  const exportConversation = useCallback(async (
+    chatId: number,
+    format: 'txt' | 'csv' | 'html',
+    outputDir: string,
+    dateFrom?: string,
+    dateTo?: string,
+    query?: string
+  ) => {
+    if (!udid) return null;
+    return sidecarCall<{ file: string; message_count: number }>(
+      'export_conversation',
+      { udid, chat_id: chatId, format, output_dir: outputDir, date_from: dateFrom, date_to: dateTo, query }
     );
-    return result.results;
   }, [udid]);
 
   return {
@@ -100,6 +133,7 @@ export function useMessages(udid: string | undefined) {
     loadConversations,
     loadMessages,
     searchMessages,
+    exportConversation,
     setActiveChat,
   };
 }


### PR DESCRIPTION
## Summary

- **Export**: Wired up the previously non-functional Export button with a format selector (TXT/CSV/HTML), folder picker, and sidecar integration
- **Encoding fix**: TXT and CSV exports now use `utf-8-sig` (BOM) so emoji and special characters render correctly in Windows apps
- **Attachment labels**: Image/video/audio attachments export as `[Image: filename.jpg]` instead of garbled binary strings
- **In-conversation search**: Filter bar below the chat header lets users search message text within the active conversation; results replace the message list
- **Date range filtering**: Preset shortcuts (3 months, 6 months, 1 year, This year, All time) populate editable from/to date pickers; filters use local timezone midnight to avoid off-by-one day issues
- **Filtered export**: Export respects active search and date filters — button label changes to "Export filtered" when filters are active
- **Nanosecond-aware timestamps**: Backend detects whether the SMS DB stores timestamps in seconds or nanoseconds (iOS 14+) and scales filter values accordingly

## Test plan

- [ ] Open a conversation → verify filter bar appears with search input, preset buttons, and date pickers
- [ ] Search for a word → only matching messages shown, count shows "X matching messages"
- [ ] Click a preset (e.g. Last year) → date fields populate and messages filter to that range
- [ ] Edit a date field manually → list updates immediately
- [ ] Click Clear → full message history restores
- [ ] Export with no filters → full conversation exported
- [ ] Set date range, click Export filtered → file contains only messages in that range
- [ ] Combine search + date range, export → both filters applied in output
- [ ] Check TXT/CSV for emoji — should render correctly in Notepad/Excel

🤖 Generated with [Claude Code](https://claude.com/claude-code)