### PR TITLE
feat: automated installer distribution via GitHub Actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,46 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+  workflow_dispatch:
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        os: [macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install Node dependencies
+        run: npm ci
+
+      - name: Install Python dependencies and PyInstaller
+        run: pip install pyinstaller -r python/requirements.txt
+
+      - name: Build Python sidecar
+        run: npm run python:bundle
+
+      - name: Build Electron app
+        run: npm run build
+
+      - name: Package and publish
+        run: npx electron-builder --publish always
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -46,18 +46,28 @@
       "dist-electron/**/*.js",
       "python/dist/**/*"
     ],
-    "extraResources": [
-      {
-        "from": "python/dist/openextract-engine",
-        "to": "python/openextract-engine"
-      }
-    ],
+    "publish": {
+      "provider": "github",
+      "releaseType": "release"
+    },
     "mac": {
       "target": "dmg",
-      "category": "public.app-category.utilities"
+      "category": "public.app-category.utilities",
+      "extraResources": [
+        {
+          "from": "python/dist/openextract-engine",
+          "to": "python/openextract-engine"
+        }
+      ]
     },
     "win": {
-      "target": "nsis"
+      "target": "nsis",
+      "extraResources": [
+        {
+          "from": "python/dist/openextract-engine.exe",
+          "to": "python/openextract-engine.exe"
+        }
+      ]
     }
   }
 }


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/release.yml` — CI/CD pipeline that builds and publishes installers to GitHub Releases on `v*.*.*` tags or manual trigger
- Fixes `extraResources` in `package.json` — moved to platform-specific sections so Windows correctly bundles `openextract-engine.exe` (was missing before)
- Adds `publish` config to electron-builder pointing to GitHub as the release provider

## How it works
Push a version tag to trigger a release:
```bash
git tag v0.1.0
git push origin v0.1.0
```
Two parallel jobs (macOS + Windows) will build the Python sidecar with PyInstaller, package the Electron app, and attach the artifacts to a GitHub Release automatically. Uses the built-in `GITHUB_TOKEN` — no secrets to configure.

## Test plan
- [ ] Trigger workflow manually via Actions tab (`workflow_dispatch`) to verify both jobs complete
- [ ] Push a test tag (`v0.1.0-test`) and confirm GitHub Release is created with `.dmg` and `-Setup.exe` artifacts
- [ ] Download and run the installer on each platform, verify app launches and sidecar connects

🤖 Generated with [Claude Code](https://claude.com/claude-code)