### PR TITLE
Fix TypeScript project references for CI

### DIFF
--- a/python/browser_history.py
+++ b/python/browser_history.py
@@ -8,7 +8,6 @@ import os
 import sys
 from datetime import datetime, timezone
 from urllib.parse import urlparse
-from typing import Optional
 
 from messages import apple_date_to_iso
 

--- a/python/messages.py
+++ b/python/messages.py
@@ -720,7 +720,7 @@ class MessageExtractor:
                             len(_rs.encode('utf-8')),
                             len(_rs.encode('utf-16-le')) // 2,
                         )
-                        if any(abs(l - _declared) <= 8 for l in _lens):
+                        if any(abs(length - _declared) <= 8 for length in _lens):
                             msg_text = _remainder
 
                 # Skip messages that are redundant or have no displayable content

--- a/python/stats.py
+++ b/python/stats.py
@@ -7,7 +7,7 @@ import sqlite3
 from datetime import datetime, timezone, timedelta
 from typing import Optional
 
-from messages import apple_date_to_iso, APPLE_EPOCH, NANOSECOND_THRESHOLD
+from messages import apple_date_to_iso, NANOSECOND_THRESHOLD
 
 
 # Seconds between Unix epoch (1970) and Apple epoch (2001)

--- a/python/tests/test_backup.py
+++ b/python/tests/test_backup.py
@@ -267,7 +267,7 @@ class TestStartBackup(unittest.TestCase):
         mb2.__aenter__ = AsyncMock(return_value=mb2)
         mb2.__aexit__ = AsyncMock(return_value=False)
         mb2.backup = AsyncMock()
-        mb2.change_backup_password = AsyncMock()
+        mb2.change_password = AsyncMock()
         return mb2
 
     def test_backup_success_returns_path(self):
@@ -343,7 +343,7 @@ class TestStartBackup(unittest.TestCase):
         self.assertIn(80, percents)
 
     def test_encrypted_backup_calls_configure(self):
-        """When encrypted=True, change_backup_password should be invoked."""
+        """When encrypted=True, change_password should be invoked."""
         lockdown = _make_lockdown_mock()
         mb2 = self._make_mb2_mock()
 
@@ -359,9 +359,9 @@ class TestStartBackup(unittest.TestCase):
                 notify=self.notify,
             )
 
-        # change_backup_password should have been called once (in _configure_encryption)
+        # change_password should have been called once (in _configure_encryption)
         # and backup() once.  We use a shared mb2 mock so both calls are visible.
-        self.assertTrue(mb2.change_backup_password.called or mb2.backup.called)
+        self.assertTrue(mb2.change_password.called or mb2.backup.called)
 
     def test_backup_error_propagates(self):
         """Exceptions from the backup service should propagate to the caller."""

--- a/python/tests/test_backup.py
+++ b/python/tests/test_backup.py
@@ -92,6 +92,7 @@ def _make_lockdown_mock(udid="abc-123", name="iPhone 15", ios_version="17.4"):
     m.udid = udid
     m.display_name = name
     m.product_version = ios_version
+    m.get_value = AsyncMock(return_value=False)
     return m
 
 
@@ -263,7 +264,10 @@ class TestStartBackup(unittest.TestCase):
         mb2 = MagicMock()
         mb2.__enter__ = MagicMock(return_value=mb2)
         mb2.__exit__ = MagicMock(return_value=False)
-        mb2.backup = MagicMock()
+        mb2.__aenter__ = AsyncMock(return_value=mb2)
+        mb2.__aexit__ = AsyncMock(return_value=False)
+        mb2.backup = AsyncMock()
+        mb2.change_backup_password = AsyncMock()
         return mb2
 
     def test_backup_success_returns_path(self):

--- a/python/tests/test_backup.py
+++ b/python/tests/test_backup.py
@@ -52,7 +52,14 @@ def _install_stub():
         "pymobiledevice3.remote.utils",
         "pymobiledevice3.remote.remote_service_discovery",
     ]:
-        sys.modules[name] = getattr(stub, name.split(".", 1)[1]) if "." in name else stub
+        if "." in name:
+            parts = name.split(".")[1:]  # skip "pymobiledevice3"
+            obj = stub
+            for part in parts:
+                obj = getattr(obj, part)
+            sys.modules[name] = obj
+        else:
+            sys.modules[name] = stub
     return stub
 
 

--- a/python/tests/test_backup.py
+++ b/python/tests/test_backup.py
@@ -17,18 +17,26 @@ from unittest.mock import MagicMock, patch
 # real library being present in the test environment.
 # ---------------------------------------------------------------------------
 
+def _make_package(name):
+    """Create a module that Python treats as a package (has __path__)."""
+    mod = types.ModuleType(name)
+    mod.__path__ = []
+    return mod
+
+
 def _make_pymobiledevice3_stub():
     """Return a minimal stub package tree for pymobiledevice3."""
-    pkg = types.ModuleType("pymobiledevice3")
+    pkg = _make_package("pymobiledevice3")
     pkg.usbmux = types.ModuleType("pymobiledevice3.usbmux")
     pkg.lockdown = types.ModuleType("pymobiledevice3.lockdown")
-    pkg.services = types.ModuleType("pymobiledevice3.services")
+    pkg.services = _make_package("pymobiledevice3.services")
     pkg.services.mobilebackup2 = types.ModuleType("pymobiledevice3.services.mobilebackup2")
-    pkg.remote = types.ModuleType("pymobiledevice3.remote")
+    pkg.remote = _make_package("pymobiledevice3.remote")
     pkg.remote.utils = types.ModuleType("pymobiledevice3.remote.utils")
     pkg.remote.remote_service_discovery = types.ModuleType(
         "pymobiledevice3.remote.remote_service_discovery"
     )
+    pkg.exceptions = types.ModuleType("pymobiledevice3.exceptions")
 
     # Populate with MagicMocks so attribute access works
     pkg.usbmux.list_devices = MagicMock(return_value=[])
@@ -36,6 +44,10 @@ def _make_pymobiledevice3_stub():
     pkg.services.mobilebackup2.Mobilebackup2Service = MagicMock()
     pkg.remote.utils.get_rsds = MagicMock(return_value=[])
     pkg.remote.remote_service_discovery.RemoteServiceDiscoveryService = MagicMock()
+
+    # Exception classes used in device_backup.py
+    pkg.exceptions.ConnectionFailedToUsbmuxdError = type("ConnectionFailedToUsbmuxdError", (Exception,), {})
+    pkg.exceptions.ConnectionTerminatedError = type("ConnectionTerminatedError", (Exception,), {})
 
     return pkg
 
@@ -51,6 +63,7 @@ def _install_stub():
         "pymobiledevice3.remote",
         "pymobiledevice3.remote.utils",
         "pymobiledevice3.remote.remote_service_discovery",
+        "pymobiledevice3.exceptions",
     ]:
         if "." in name:
             parts = name.split(".")[1:]  # skip "pymobiledevice3"

--- a/python/tests/test_backup.py
+++ b/python/tests/test_backup.py
@@ -9,7 +9,7 @@ module can be imported even when pymobiledevice3 is not installed.
 import sys
 import types
 import unittest
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 
 # ---------------------------------------------------------------------------
@@ -39,8 +39,8 @@ def _make_pymobiledevice3_stub():
     pkg.exceptions = types.ModuleType("pymobiledevice3.exceptions")
 
     # Populate with MagicMocks so attribute access works
-    pkg.usbmux.list_devices = MagicMock(return_value=[])
-    pkg.lockdown.create_using_usbmux = MagicMock()
+    pkg.usbmux.list_devices = AsyncMock(return_value=[])
+    pkg.lockdown.create_using_usbmux = AsyncMock()
     pkg.services.mobilebackup2.Mobilebackup2Service = MagicMock()
     pkg.remote.utils.get_rsds = MagicMock(return_value=[])
     pkg.remote.remote_service_discovery.RemoteServiceDiscoveryService = MagicMock()
@@ -117,8 +117,8 @@ class TestListDevices(unittest.TestCase):
         lockdown = _make_lockdown_mock("DEV-1", "Alice's iPhone", "17.4")
 
         with (
-            patch("pymobiledevice3.usbmux.list_devices", return_value=[usbmux_dev]),
-            patch("pymobiledevice3.lockdown.create_using_usbmux", return_value=lockdown),
+            patch("pymobiledevice3.usbmux.list_devices", new_callable=AsyncMock, return_value=[usbmux_dev]),
+            patch("pymobiledevice3.lockdown.create_using_usbmux", new_callable=AsyncMock, return_value=lockdown),
             patch("pymobiledevice3.remote.utils.get_rsds", return_value=[]),
         ):
             result = self.manager.list_devices()
@@ -136,8 +136,8 @@ class TestListDevices(unittest.TestCase):
         lockdown = _make_lockdown_mock("DEV-2", "Bob's iPhone", "16.7")
 
         with (
-            patch("pymobiledevice3.usbmux.list_devices", return_value=[usbmux_dev]),
-            patch("pymobiledevice3.lockdown.create_using_usbmux", return_value=lockdown),
+            patch("pymobiledevice3.usbmux.list_devices", new_callable=AsyncMock, return_value=[usbmux_dev]),
+            patch("pymobiledevice3.lockdown.create_using_usbmux", new_callable=AsyncMock, return_value=lockdown),
             patch("pymobiledevice3.remote.utils.get_rsds", return_value=[]),
         ):
             result = self.manager.list_devices()
@@ -163,7 +163,7 @@ class TestListDevices(unittest.TestCase):
         }.get(key, "")
 
         with (
-            patch("pymobiledevice3.usbmux.list_devices", return_value=[]),
+            patch("pymobiledevice3.usbmux.list_devices", new_callable=AsyncMock, return_value=[]),
             patch("pymobiledevice3.remote.utils.get_rsds", return_value=[rsd_mock]),
             patch(
                 "pymobiledevice3.remote.remote_service_discovery.RemoteServiceDiscoveryService",
@@ -196,8 +196,8 @@ class TestListDevices(unittest.TestCase):
         rsd_service_mock.get_value = lambda key: ""
 
         with (
-            patch("pymobiledevice3.usbmux.list_devices", return_value=[usbmux_dev]),
-            patch("pymobiledevice3.lockdown.create_using_usbmux", return_value=lockdown),
+            patch("pymobiledevice3.usbmux.list_devices", new_callable=AsyncMock, return_value=[usbmux_dev]),
+            patch("pymobiledevice3.lockdown.create_using_usbmux", new_callable=AsyncMock, return_value=lockdown),
             patch("pymobiledevice3.remote.utils.get_rsds", return_value=[rsd_mock]),
             patch(
                 "pymobiledevice3.remote.remote_service_discovery.RemoteServiceDiscoveryService",
@@ -222,8 +222,8 @@ class TestListDevices(unittest.TestCase):
             return good_lockdown
 
         with (
-            patch("pymobiledevice3.usbmux.list_devices", return_value=[good_dev, bad_dev]),
-            patch("pymobiledevice3.lockdown.create_using_usbmux", side_effect=_create_lockdown),
+            patch("pymobiledevice3.usbmux.list_devices", new_callable=AsyncMock, return_value=[good_dev, bad_dev]),
+            patch("pymobiledevice3.lockdown.create_using_usbmux", new_callable=AsyncMock, side_effect=_create_lockdown),
             patch("pymobiledevice3.remote.utils.get_rsds", return_value=[]),
         ):
             result = self.manager.list_devices()
@@ -271,7 +271,7 @@ class TestStartBackup(unittest.TestCase):
         mb2 = self._make_mb2_mock()
 
         with (
-            patch("pymobiledevice3.lockdown.create_using_usbmux", return_value=lockdown),
+            patch("pymobiledevice3.lockdown.create_using_usbmux", new_callable=AsyncMock, return_value=lockdown),
             patch("pymobiledevice3.services.mobilebackup2.Mobilebackup2Service", return_value=mb2),
         ):
             result = self.manager.start_backup(
@@ -291,7 +291,7 @@ class TestStartBackup(unittest.TestCase):
         mb2 = self._make_mb2_mock()
 
         with (
-            patch("pymobiledevice3.lockdown.create_using_usbmux", return_value=lockdown),
+            patch("pymobiledevice3.lockdown.create_using_usbmux", new_callable=AsyncMock, return_value=lockdown),
             patch("pymobiledevice3.services.mobilebackup2.Mobilebackup2Service", return_value=mb2),
         ):
             self.manager.start_backup(
@@ -322,7 +322,7 @@ class TestStartBackup(unittest.TestCase):
         mb2.backup.side_effect = _fake_backup
 
         with (
-            patch("pymobiledevice3.lockdown.create_using_usbmux", return_value=lockdown),
+            patch("pymobiledevice3.lockdown.create_using_usbmux", new_callable=AsyncMock, return_value=lockdown),
             patch("pymobiledevice3.services.mobilebackup2.Mobilebackup2Service", return_value=mb2),
         ):
             self.manager.start_backup(
@@ -344,7 +344,7 @@ class TestStartBackup(unittest.TestCase):
         mb2 = self._make_mb2_mock()
 
         with (
-            patch("pymobiledevice3.lockdown.create_using_usbmux", return_value=lockdown),
+            patch("pymobiledevice3.lockdown.create_using_usbmux", new_callable=AsyncMock, return_value=lockdown),
             patch("pymobiledevice3.services.mobilebackup2.Mobilebackup2Service", return_value=mb2),
         ):
             self.manager.start_backup(
@@ -366,7 +366,7 @@ class TestStartBackup(unittest.TestCase):
         mb2.backup.side_effect = RuntimeError("Device disconnected")
 
         with (
-            patch("pymobiledevice3.lockdown.create_using_usbmux", return_value=lockdown),
+            patch("pymobiledevice3.lockdown.create_using_usbmux", new_callable=AsyncMock, return_value=lockdown),
             patch("pymobiledevice3.services.mobilebackup2.Mobilebackup2Service", return_value=mb2),
         ):
             with self.assertRaises(RuntimeError, msg="Device disconnected"):
@@ -391,7 +391,7 @@ class TestStartBackup(unittest.TestCase):
             self.assertFalse(os.path.exists(target))
 
             with (
-                patch("pymobiledevice3.lockdown.create_using_usbmux", return_value=lockdown),
+                patch("pymobiledevice3.lockdown.create_using_usbmux", new_callable=AsyncMock, return_value=lockdown),
                 patch(
                     "pymobiledevice3.services.mobilebackup2.Mobilebackup2Service",
                     return_value=mb2,
@@ -419,7 +419,7 @@ class TestStartBackup(unittest.TestCase):
         mb2.backup.side_effect = _fake_backup
 
         with (
-            patch("pymobiledevice3.lockdown.create_using_usbmux", return_value=lockdown),
+            patch("pymobiledevice3.lockdown.create_using_usbmux", new_callable=AsyncMock, return_value=lockdown),
             patch("pymobiledevice3.services.mobilebackup2.Mobilebackup2Service", return_value=mb2),
         ):
             self.manager.start_backup(

--- a/src/components/explore/BrowserHistoryOverview.tsx
+++ b/src/components/explore/BrowserHistoryOverview.tsx
@@ -159,7 +159,7 @@ export default function BrowserHistoryOverview({ visits, onSelectDomain, onSelec
                     if (!active || !payload?.length) return null;
                     return (
                       <div className="bg-white border border-gray-200 rounded shadow-sm px-3 py-2 text-xs">
-                        <div className="font-medium text-gray-700">{formatDate(label)}</div>
+                        <div className="font-medium text-gray-700">{formatDate(String(label))}</div>
                         <div className="text-emerald-600">{payload[0]?.value} visits</div>
                         {payload[1]?.value != null && (
                           <div className="text-indigo-400">{payload[1].value} avg</div>

--- a/src/components/photos/PhotoThumbnail.tsx
+++ b/src/components/photos/PhotoThumbnail.tsx
@@ -74,7 +74,7 @@ const PhotoThumbnail = memo(function PhotoThumbnail({
           ) : skipThumbnail ? (
             <Play className="w-8 h-8 opacity-40" />
           ) : hasError ? (
-            <AlertTriangle className="w-5 h-5 opacity-30" title={`Could not load: ${photo.filename}`} />
+            <span title={`Could not load: ${photo.filename}`}><AlertTriangle className="w-5 h-5 opacity-30" /></span>
           ) : (
             <Image className="w-5 h-5 opacity-40" />
           )}

--- a/tsconfig.electron.json
+++ b/tsconfig.electron.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "composite": true,
     "target": "ES2020",
     "module": "commonjs",
     "outDir": "dist-electron",
@@ -9,9 +10,7 @@
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
-    "resolveJsonModule": true,
-    "declaration": false,
-    "outDir": "dist-electron"
+    "resolveJsonModule": true
   },
   "include": [
     "electron/**/*.ts"


### PR DESCRIPTION
## Summary
- Add `composite: true` to `tsconfig.electron.json` so project references work with `tsc --noEmit`
- Remove duplicate `outDir` and conflicting `declaration: false`
- Fixes CI TypeScript check failure from #55

## Test plan
- [ ] CI TypeScript checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)