### PR TITLE
ci: decouple website deploy from Release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -109,7 +109,7 @@ jobs:
               echo "No website changes needed"
             else
               git add "$FILE"
-              git commit -m "chore: update website download URLs to v${VERSION}"
+              git commit -m "chore: update website download URLs to v${VERSION} [skip ci]"
               git push
               echo "Website updated to v${VERSION}"
             fi

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -1,9 +1,18 @@
 name: Deploy Website
 
 on:
+  # Deploy automatically when website files change on main
+  push:
+    branches: [main]
+    paths:
+      - 'website/**'
+      - '.github/workflows/website.yml'
+  # Deploy after a successful Release (so updated download URLs ship)
   workflow_run:
     workflows: [Release]
     types: [completed]
+  # Manual trigger for forced redeploys
+  workflow_dispatch:
 
 concurrency:
   group: website-deploy
@@ -11,7 +20,9 @@ concurrency:
 
 jobs:
   deploy:
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    # For workflow_run events, only deploy on successful Release.
+    # For push / workflow_dispatch, always deploy.
+    if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
@@ -24,7 +35,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
         with:
-          ref: ${{ github.event.workflow_run.head_branch }}
+          # For workflow_run, check out the branch that ran the Release.
+          # For push / workflow_dispatch, fall back to the default ref.
+          ref: ${{ github.event.workflow_run.head_branch || github.ref }}
 
       - name: Setup Pages
         uses: actions/configure-pages@v6


### PR DESCRIPTION
## Summary

Decouples website deploys from the Release workflow so website-only edits can ship without cutting an app release.

- Adds a `push` trigger on `main` scoped to `website/**` and `.github/workflows/website.yml` for automatic redeploys on content changes.
- Adds a `workflow_dispatch` trigger for manual redeploys.
- Keeps the existing `workflow_run` trigger on Release completion so the post-build deploy still ships the updated download URLs.
- Adds `[skip ci]` to release.yml's auto-commit of the website URL bump so the release flow's early URL-bump commit doesn't fire the new push trigger mid-build. The post-build `workflow_run` handles the deploy once artifacts exist, avoiding a brief link-404 window.

## What changed

- `.github/workflows/website.yml` — new triggers + concurrency group + updated `if:` guard and checkout ref to handle all three trigger types.
- `.github/workflows/release.yml` — one-line change: append `[skip ci]` to the auto-commit message that bumps website download URLs.

## Test plan

- [ ] After merge, push a trivial change under `website/**` and confirm Deploy Website runs automatically.
- [ ] Click "Run workflow" on Deploy Website from the Actions tab and confirm the manual dispatch works.
- [ ] On the next release, confirm the URL-bump commit does NOT trigger Deploy Website, and that the post-build `workflow_run` still deploys the updated site.