### PR TITLE
feat(ui): show app version in window titlebar

### DIFF
--- a/dist-electron/main.js
+++ b/dist-electron/main.js
@@ -71,13 +71,14 @@ function createWindow() {
         height: 750,
         minWidth: 800,
         minHeight: 600,
-        title: 'OpenExtract',
+        title: `OpenExtract v${app.getVersion()}`,
         webPreferences: {
             preload: path.join(__dirname, 'preload.js'),
             contextIsolation: true,
             nodeIntegration: false,
         },
     });
+    mainWindow.on('page-title-updated', (e) => e.preventDefault());
     if (isDev) {
         mainWindow.loadURL('http://127.0.0.1:5179');
         mainWindow.webContents.openDevTools();

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -83,13 +83,15 @@ function createWindow() {
     height: 750,
     minWidth: 800,
     minHeight: 600,
-    title: 'OpenExtract',
+    title: `OpenExtract v${app.getVersion()}`,
     webPreferences: {
       preload: path.join(__dirname, 'preload.js'),
       contextIsolation: true,
       nodeIntegration: false,
     },
   });
+
+  mainWindow.on('page-title-updated', (e: any) => e.preventDefault());
 
   if (isDev) {
     mainWindow.loadURL('http://127.0.0.1:5179');


### PR DESCRIPTION
## Summary
- Append `v${app.getVersion()}` to the Electron window title so the running build is visible at a glance
- Prevent the renderer's `<title>` tag from overriding the window title

## Test plan
- [ ] `npm run dev` — window title reads `OpenExtract v0.3.4`
- [ ] Title stays stable after renderer load (no flash back to plain `OpenExtract`)

Note: release workflow is manual (`workflow_dispatch`), so merging this will not trigger a release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)