### PR TITLE
ci(release): clone ios-backup-core sibling before pip install

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -100,8 +100,23 @@ jobs:
       - name: TypeScript check (electron)
         run: npx tsc --noEmit -p tsconfig.electron.json
 
+      # python/requirements.txt installs ios-backup-core via `-e ../../ios-backup-core`.
+      # The expected layout is openextract/ and ios-backup-core/ as siblings on disk,
+      # so clone ios-backup-core one level above $GITHUB_WORKSPACE before pip runs.
+      # TODO: remove this step once ios-backup-core ships to PyPI and requirements.txt
+      # pins a versioned release instead of the editable path install.
+      - name: Clone ios-backup-core (sibling for editable install)
+        shell: bash
+        run: |
+          git clone --depth=1 \
+            https://github.com/charleswest775/ios-backup-core.git \
+            "$GITHUB_WORKSPACE/../ios-backup-core"
+
+      # Run from python/ so pip resolves `-e ../../ios-backup-core` the same
+      # way it does locally (README tells devs to `cd python` first).
       - name: Install Python dependencies
-        run: pip install ruff pytest -r python/requirements.txt
+        working-directory: python
+        run: pip install ruff pytest -r requirements.txt
 
       - name: Python lint
         run: ruff check python/
@@ -177,8 +192,17 @@ jobs:
       - name: Install Node dependencies
         run: npm install
 
+      # See preflight job for rationale on sibling-clone + working-directory.
+      - name: Clone ios-backup-core (sibling for editable install)
+        shell: bash
+        run: |
+          git clone --depth=1 \
+            https://github.com/charleswest775/ios-backup-core.git \
+            "$GITHUB_WORKSPACE/../ios-backup-core"
+
       - name: Install Python dependencies and PyInstaller
-        run: pip install pyinstaller -r python/requirements.txt
+        working-directory: python
+        run: pip install pyinstaller -r requirements.txt
 
       - name: Build Python sidecar
         run: npm run python:bundle
@@ -222,8 +246,17 @@ jobs:
       - name: Install Node dependencies
         run: npm install
 
+      # See preflight job for rationale on sibling-clone + working-directory.
+      - name: Clone ios-backup-core (sibling for editable install)
+        shell: bash
+        run: |
+          git clone --depth=1 \
+            https://github.com/charleswest775/ios-backup-core.git \
+            "$GITHUB_WORKSPACE/../ios-backup-core"
+
       - name: Install Python dependencies and PyInstaller
-        run: pip install pyinstaller -r python/requirements.txt
+        working-directory: python
+        run: pip install pyinstaller -r requirements.txt
 
       - name: Build Python sidecar
         run: npm run python:bundle
@@ -270,8 +303,17 @@ jobs:
       - name: Install Node dependencies
         run: npm install
 
+      # See preflight job for rationale on sibling-clone + working-directory.
+      - name: Clone ios-backup-core (sibling for editable install)
+        shell: bash
+        run: |
+          git clone --depth=1 \
+            https://github.com/charleswest775/ios-backup-core.git \
+            "$GITHUB_WORKSPACE/../ios-backup-core"
+
       - name: Install Python dependencies and PyInstaller
-        run: pip install pyinstaller -r python/requirements.txt
+        working-directory: python
+        run: pip install pyinstaller -r requirements.txt
 
       - name: Build Python sidecar
         run: npm run python:bundle


### PR DESCRIPTION
## Summary
The v0.4.0 release kept failing at the \`Install Python dependencies\` step:

\`\`\`
ERROR: ../../ios-backup-core is not a valid editable requirement.
\`\`\`

\`python/requirements.txt\` pins \`-e ../../ios-backup-core\` — resolves fine on dev machines (\`openextract/\` and \`ios-backup-core/\` are siblings on disk), but not in CI where only \`openextract\` is checked out. \`ci.yml\` already solves this by cloning the sibling repo and running \`pip install\` from \`python/\`. \`release.yml\` was never updated to match when commit \`3c649d4\` introduced the editable dependency — which is why the last successful release (v0.3.4) predates this issue.

Mirrored the CI setup in all four release jobs: **preflight**, **build-macos**, **build-windows**, **build-linux**. The clone step uses \`shell: bash\` so the \`\$GITHUB_WORKSPACE/../ios-backup-core\` syntax works identically on the Windows runner.

Same TODO carried over from \`ci.yml\`: drop these clone steps once ios-backup-core ships to PyPI and \`requirements.txt\` can pin a versioned release.

## Test plan
- [ ] CI on this PR is green.
- [ ] After merge, re-dispatching \`Release\` with \`0.4.0\` gets past \`Install Python dependencies\` in the preflight job, tags, and runs all three platform builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)