### PR TITLE
chore: release v0.4.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openextract",
-  "version": "0.3.3",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openextract",
-      "version": "0.3.3",
+      "version": "0.4.0",
       "license": "MIT",
       "dependencies": {
         "benz-amr-recorder": "^1.1.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openextract",
-  "version": "0.3.4",
+  "version": "0.4.0",
   "description": "Free, open-source iPhone backup extractor",
   "main": "dist-electron/main.js",
   "author": "OpenExtract Contributors",

--- a/website/static/index.html
+++ b/website/static/index.html
@@ -674,7 +674,7 @@
     <div class="hero-content">
       <div class="hero-badge">
         <span class="dot"></span>
-        MIT Licensed · Free Forever · v0.3.4
+        MIT Licensed · Free Forever · v0.4.0
       </div>
       <h1>Extract iPhone<br/>backup data <em>freely.</em></h1>
       <p class="hero-sub">
@@ -865,7 +865,7 @@
         <p>No account required. No trial period. No upsell. OpenExtract is free software — download it, use it, share it.</p>
       </div>
       <div class="download-options reveal">
-        <a href="https://github.com/charleswest775/openextract/releases/download/v0.3.4/OpenExtract-Setup-0.3.4.exe" class="dl-btn primary-dl">
+        <a href="https://github.com/charleswest775/openextract/releases/download/v0.4.0/OpenExtract-Setup-0.4.0.exe" class="dl-btn primary-dl">
           <svg viewBox="0 0 20 20"><path d="M17.05 20H2.95C1.32 20 0 18.7 0 17.1V2.9C0 1.3 1.32 0 2.95 0h14.1C18.68 0 20 1.3 20 2.9v14.2c0 1.6-1.32 2.9-2.95 2.9zM10 4.5L5 10h3.5v5.5h3V10H15L10 4.5z"/></svg>
           <div class="dl-btn-text">
             <div class="dl-os">Windows 10/11</div>
@@ -873,7 +873,7 @@
           </div>
           <span class="dl-btn-arrow">↓</span>
         </a>
-        <a href="https://github.com/charleswest775/openextract/releases/download/v0.3.4/OpenExtract-0.3.4-arm64.dmg" class="dl-btn">
+        <a href="https://github.com/charleswest775/openextract/releases/download/v0.4.0/OpenExtract-0.4.0-arm64.dmg" class="dl-btn">
           <svg viewBox="0 0 20 20"><path d="M16.365 1.43c0 1.14-.493 2.27-1.177 3.08-.744.9-1.99 1.57-2.987 1.57-.12 0-.23-.02-.3-.03-.01-.06-.04-.22-.04-.39 0-1.15.572-2.27 1.206-2.98.804-.94 2.142-1.64 3.248-1.68.03.13.05.28.05.44zm4.565 15.71c-.03.07-.463 1.58-1.518 3.12-.945 1.34-1.94 2.71-3.43 2.71-1.517 0-1.9-.88-3.63-.88-1.698 0-2.302.91-3.67.91-1.377 0-2.332-1.26-3.428-2.8-1.287-1.82-2.323-4.63-2.323-7.28 0-4.28 2.797-6.55 5.552-6.55 1.448 0 2.675.95 3.6.95.865 0 2.222-1.01 3.902-1.01.613 0 2.886.06 4.374 2.19l.07.1z"/></svg>
           <div class="dl-btn-text">
             <div class="dl-os">macOS 12+</div>
@@ -881,7 +881,7 @@
           </div>
           <span class="dl-btn-arrow">↓</span>
         </a>
-        <a href="https://github.com/charleswest775/openextract/releases/download/v0.3.4/OpenExtract-0.3.4.AppImage" class="dl-btn">
+        <a href="https://github.com/charleswest775/openextract/releases/download/v0.4.0/OpenExtract-0.4.0.AppImage" class="dl-btn">
           <svg viewBox="0 0 20 20"><path d="M10.031 0C4.498 0 0 4.498 0 10.031c0 5.532 4.498 10.03 10.031 10.03 5.532 0 10.03-4.498 10.03-10.03C20.061 4.498 15.563 0 10.031 0zm0 1.5c4.71 0 8.53 3.82 8.53 8.531 0 4.71-3.82 8.53-8.53 8.53-4.71 0-8.531-3.82-8.531-8.53 0-4.71 3.82-8.53 8.531-8.53zm-.75 3v5.25H6l4.031 4.031L14.06 9.75h-3.28V4.5h-1.5z"/></svg>
           <div class="dl-btn-text">
             <div class="dl-os">Linux (x64)</div>


### PR DESCRIPTION
Auto-release sync PR (opened manually because the finalize job's ``gh pr create`` step was blocked by a shallow-checkout bug — fix incoming in a separate hotfix).

Merging this keeps ``main`` in sync with the published v0.4.0 release:
- ``package.json`` version bump to 0.4.0
- ``website/static/index.html`` download URLs updated to 0.4.0

Release: https://github.com/charleswest775/openextract/releases/tag/v0.4.0