### PR TITLE
ci(release): fix finalize sync-PR when origin/main ref is missing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -339,6 +339,13 @@ jobs:
         with:
           ref: release/v${{ inputs.version }}
           token: ${{ secrets.GITHUB_TOKEN }}
+          # Full history + all branches so `origin/main..HEAD` resolves in the
+          # sync-PR step below. Default shallow checkout only fetches the ref
+          # we asked for, so origin/main is missing from the local repo.
+          fetch-depth: 0
+
+      - name: Fetch main for comparison
+        run: git fetch --no-tags origin main:refs/remotes/origin/main
 
       - name: Publish release (remove draft)
         env:


### PR DESCRIPTION
## Summary
v0.4.0 shipped successfully (release live, 10 artifacts across mac/windows/linux), but the finalize job's "Open sync PR to main" step failed with:

\`\`\`
fatal: ambiguous argument 'origin/main..HEAD': unknown revision or path not in the working tree.
\`\`\`

The finalize job checks out only \`release/vX.Y.Z\` using \`actions/checkout\`'s default (shallow, single-ref), so the local repo has no ref for \`origin/main\` — \`git rev-list --count origin/main..HEAD\` then blows up.

Fix is minimal: \`fetch-depth: 0\` so full history is available, plus an explicit \`git fetch\` for \`origin/main\` as a remote-tracking ref before the comparison. The rest of the sync-PR logic was correct, just missing its prerequisite git state.

## Impact on v0.4.0
None — the release is fully published. Draft-removal ran before this failure. The sync PR was opened manually as #68 so \`main\` still picks up the package.json bump and website URL updates.

## Test plan
- [ ] CI green on this PR.
- [ ] Next release dispatch produces a sync PR automatically in the finalize step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)