### PR TITLE
site: publish SEO meta + analytics + subpage nav on homepage

### DIFF
--- a/website/static/for/investigators.html
+++ b/website/static/for/investigators.html
@@ -32,6 +32,12 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=DM+Sans:ital,opsz,wght@0,9..40,300;0,9..40,400;0,9..40,500;0,9..40,600;1,9..40,300&family=DM+Mono:wght@400;500&family=Playfair+Display:wght@600;700&display=swap" rel="stylesheet" />
   <link rel="stylesheet" href="/css/pages.css" />
+
+  <!-- Plausible Analytics — privacy-respecting, no cookies -->
+  <script defer data-domain="openextract.app" src="https://plausible.io/js/script.outbound-links.file-downloads.tagged-events.js"></script>
+  <script>
+    window.plausible = window.plausible || function() { (window.plausible.q = window.plausible.q || []).push(arguments) }
+  </script>
 </head>
 <body>
 

--- a/website/static/for/legal.html
+++ b/website/static/for/legal.html
@@ -32,6 +32,12 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=DM+Sans:ital,opsz,wght@0,9..40,300;0,9..40,400;0,9..40,500;0,9..40,600;1,9..40,300&family=DM+Mono:wght@400;500&family=Playfair+Display:wght@600;700&display=swap" rel="stylesheet" />
   <link rel="stylesheet" href="/css/pages.css" />
+
+  <!-- Plausible Analytics — privacy-respecting, no cookies -->
+  <script defer data-domain="openextract.app" src="https://plausible.io/js/script.outbound-links.file-downloads.tagged-events.js"></script>
+  <script>
+    window.plausible = window.plausible || function() { (window.plausible.q = window.plausible.q || []).push(arguments) }
+  </script>
 </head>
 <body>
 

--- a/website/static/for/personal.html
+++ b/website/static/for/personal.html
@@ -32,6 +32,12 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=DM+Sans:ital,opsz,wght@0,9..40,300;0,9..40,400;0,9..40,500;0,9..40,600;1,9..40,300&family=DM+Mono:wght@400;500&family=Playfair+Display:wght@600;700&display=swap" rel="stylesheet" />
   <link rel="stylesheet" href="/css/pages.css" />
+
+  <!-- Plausible Analytics — privacy-respecting, no cookies -->
+  <script defer data-domain="openextract.app" src="https://plausible.io/js/script.outbound-links.file-downloads.tagged-events.js"></script>
+  <script>
+    window.plausible = window.plausible || function() { (window.plausible.q = window.plausible.q || []).push(arguments) }
+  </script>
 </head>
 <body>
 

--- a/website/static/index.html
+++ b/website/static/index.html
@@ -2,9 +2,109 @@
 
 <html lang="en">
 <head>
-  <meta charset="UTF-8" />
+  <!-- Primary meta -->
+  <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>OpenExtract — Free iPhone Backup Extractor</title>
+  <meta name="theme-color" content="#0b1220" />
+  <title>OpenExtract — Free, Open-Source iPhone Backup Extractor</title>
+  <meta name="description" content="Free, open-source iPhone backup extractor. Recover messages, photos, contacts, and call history from iTunes/Finder backups — including encrypted ones. 100% local. Windows, macOS, Linux." />
+  <link rel="canonical" href="https://www.openextract.app/" />
+  <meta name="robots" content="index, follow, max-image-preview:large" />
+  <meta name="author" content="OpenExtract" />
+
+  <!-- Open Graph -->
+  <meta property="og:type" content="website" />
+  <meta property="og:site_name" content="OpenExtract" />
+  <meta property="og:url" content="https://www.openextract.app/" />
+  <meta property="og:title" content="OpenExtract — Free, Open-Source iPhone Backup Extractor" />
+  <meta property="og:description" content="Recover messages, photos, contacts, and more from iPhone backups — encrypted or not. Free, MIT-licensed, 100% local." />
+  <meta property="og:image" content="https://www.openextract.app/img/og-image.png" />
+  <meta property="og:image:width" content="1200" />
+  <meta property="og:image:height" content="630" />
+  <meta property="og:image:alt" content="OpenExtract: free, open-source iPhone backup extractor. Windows, macOS, Linux." />
+  <meta property="og:locale" content="en_US" />
+
+  <!-- Twitter / X card -->
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="OpenExtract — Free iPhone Backup Extractor" />
+  <meta name="twitter:description" content="Recover messages, photos, contacts from iPhone backups — encrypted or not. Free, MIT-licensed, 100% local." />
+  <meta name="twitter:image" content="https://www.openextract.app/img/og-image.png" />
+  <meta name="twitter:image:alt" content="OpenExtract: free, open-source iPhone backup extractor. Windows, macOS, Linux." />
+
+  <!-- Favicon -->
+  <link rel="icon" href="/favicon.ico" sizes="any" />
+  <link rel="icon" type="image/svg+xml" href="/img/logo.svg" />
+
+  <!-- Structured data: SoftwareApplication -->
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "SoftwareApplication",
+    "name": "OpenExtract",
+    "alternateName": "openextract",
+    "description": "Free, open-source desktop application for extracting messages, photos, contacts, call history, voicemails, and app data from iPhone and iPad backups — including encrypted backups. Runs 100% locally.",
+    "applicationCategory": "UtilityApplication",
+    "applicationSubCategory": "DataExtraction",
+    "operatingSystem": "Windows 10, Windows 11, macOS 12+, Linux",
+    "url": "https://www.openextract.app/",
+    "downloadUrl": "https://github.com/charleswest775/openextract/releases",
+    "license": "https://opensource.org/licenses/MIT",
+    "isAccessibleForFree": true,
+    "offers": {
+      "@type": "Offer",
+      "price": "0",
+      "priceCurrency": "USD"
+    },
+    "featureList": [
+      "SMS and iMessage extraction",
+      "Photo and video recovery with EXIF preserved",
+      "Encrypted backup support",
+      "Call history export",
+      "Contacts and calendar export",
+      "Voicemail extraction",
+      "Export to PDF, CSV, HTML",
+      "100% local processing, no cloud upload"
+    ],
+    "author": {
+      "@type": "Organization",
+      "name": "OpenExtract",
+      "url": "https://www.openextract.app/"
+    },
+    "sameAs": [
+      "https://github.com/charleswest775/openextract"
+    ]
+  }
+  </script>
+
+  <!-- Structured data: Organization -->
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "Organization",
+    "name": "OpenExtract",
+    "url": "https://www.openextract.app/",
+    "sameAs": [
+      "https://github.com/charleswest775/openextract"
+    ]
+  }
+  </script>
+
+  <!-- Structured data: WebSite -->
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "WebSite",
+    "name": "OpenExtract",
+    "url": "https://www.openextract.app/"
+  }
+  </script>
+
+  <!-- Plausible Analytics — privacy-respecting, no cookies -->
+  <script defer data-domain="openextract.app" src="https://plausible.io/js/script.outbound-links.file-downloads.tagged-events.js"></script>
+  <script>
+    window.plausible = window.plausible || function() { (window.plausible.q = window.plausible.q || []).push(arguments) }
+  </script>
+
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=DM+Sans:ital,opsz,wght@0,9..40,300;0,9..40,400;0,9..40,500;0,9..40,600;1,9..40,300&family=DM+Mono:wght@400;500&family=Playfair+Display:wght@600;700&display=swap" rel="stylesheet" />
@@ -661,8 +761,8 @@
     </a>
     <ul class="nav-links">
       <li><a href="#features">Features</a></li>
-      <li><a href="#use-cases">Use Cases</a></li>
-      <li><a href="#open-source">Open Source</a></li>
+      <li><a href="/vs-imazing">vs iMazing</a></li>
+      <li><a href="/for/legal">For legal</a></li>
       <li><a href="#download" class="nav-cta">Download Free</a></li>
     </ul>
   </nav>
@@ -906,7 +1006,10 @@
     </div>
     <nav>
       <a href="#features">Features</a>
-      <a href="#use-cases">Use Cases</a>
+      <a href="/vs-imazing">vs iMazing</a>
+      <a href="/for/legal">For legal</a>
+      <a href="/for/investigators">For investigators</a>
+      <a href="/for/personal">For personal</a>
       <a href="https://github.com/charleswest775/openextract">GitHub</a>
       <a href="https://github.com/charleswest775/openextract/issues">Support</a>
     </nav>

--- a/website/static/vs-imazing.html
+++ b/website/static/vs-imazing.html
@@ -33,6 +33,12 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=DM+Sans:ital,opsz,wght@0,9..40,300;0,9..40,400;0,9..40,500;0,9..40,600;1,9..40,300&family=DM+Mono:wght@400;500&family=Playfair+Display:wght@600;700&display=swap" rel="stylesheet" />
   <link rel="stylesheet" href="/css/pages.css" />
+
+  <!-- Plausible Analytics — privacy-respecting, no cookies -->
+  <script defer data-domain="openextract.app" src="https://plausible.io/js/script.outbound-links.file-downloads.tagged-events.js"></script>
+  <script>
+    window.plausible = window.plausible || function() { (window.plausible.q = window.plausible.q || []).push(arguments) }
+  </script>
 </head>
 <body>
 


### PR DESCRIPTION
## Summary

- **Homepage SEO meta**: add full meta/OG/Twitter tags + JSON-LD structured data (SoftwareApplication, Organization, WebSite). Homepage was missing all SEO signals while subpages already had them.
- **Plausible analytics**: add privacy-respecting analytics snippet to homepage and all four subpages (`for/legal.html`, `for/personal.html`, `for/investigators.html`, `vs-imazing.html`). Previously zero tracking anywhere on the site.
- **Subpage discovery**: wire up top nav (vs-imazing + for/legal) and footer (all four subpages + GitHub). Homepage was a navigational dead-end.

## Test plan

- [ ] View source on https://openextract.app after deploy — confirm Plausible `<script>` tag present
- [ ] Confirm 3 JSON-LD blocks in homepage source (SoftwareApplication, Organization, WebSite)
- [ ] Verify top nav links to vs-imazing and for/legal work
- [ ] Verify footer links to all subpages and GitHub
- [ ] Check Plausible dashboard starts receiving pageviews after domain registration