### PR TITLE
fix: add vercel.json with cleanUrls for extensionless URLs

### DIFF
--- a/website/static/vercel.json
+++ b/website/static/vercel.json
@@ -1,0 +1,3 @@
+{
+  "cleanUrls": true
+}


### PR DESCRIPTION
## Summary

- Adds `vercel.json` with `cleanUrls: true` to `website/static/`
- All nav links across the site use extensionless paths (`/vs-imazing`, `/for/legal`, etc.) but Vercel was returning 404s because it requires this setting to serve `foo.html` at `/foo`

## Test plan

- [ ] After deploy, verify https://openextract.app/vs-imazing loads (was 404)
- [ ] Verify https://openextract.app/for/legal loads (was 404)
- [ ] Verify https://openextract.app/for/investigators and /for/personal also work