### PR TITLE
site: point download links at real installers + refresh sizes

### DIFF
--- a/website/static/how-it-works.html
+++ b/website/static/how-it-works.html
@@ -116,17 +116,17 @@
         <p>If you don't have a backup yet, plug your iPhone in, open Finder (or iTunes on Windows), and click "Back up now." Then come back here.</p>
       </div>
       <div class="inline-download__list">
-        <a class="dl-row dl-row--primary" href="https://github.com/charleswest775/openextract/releases">
+        <a class="dl-row dl-row--primary" href="https://github.com/charleswest775/openextract/releases/download/v0.4.0/OpenExtract-0.4.0-arm64.dmg">
           <span class="dl-row__os">Download for macOS</span>
-          <span class="dl-row__meta">Apple Silicon · 48 MB</span>
+          <span class="dl-row__meta">Apple Silicon · 144 MB</span>
         </a>
-        <a class="dl-row" href="https://github.com/charleswest775/openextract/releases">
+        <a class="dl-row" href="https://github.com/charleswest775/openextract/releases/download/v0.4.0/OpenExtract-Setup-0.4.0.exe">
           <span class="dl-row__os">Download for Windows</span>
-          <span class="dl-row__meta">10 &amp; 11 · 56 MB</span>
+          <span class="dl-row__meta">10 &amp; 11 · 175 MB</span>
         </a>
-        <a class="dl-row" href="https://github.com/charleswest775/openextract/releases">
+        <a class="dl-row" href="https://github.com/charleswest775/openextract/releases/download/v0.4.0/OpenExtract-0.4.0.AppImage">
           <span class="dl-row__os">Download for Linux</span>
-          <span class="dl-row__meta">AppImage · 46 MB</span>
+          <span class="dl-row__meta">AppImage · 176 MB</span>
         </a>
       </div>
     </div>

--- a/website/static/index.html
+++ b/website/static/index.html
@@ -102,7 +102,7 @@
       </h1>
       <p class="hero__sub">Pull the messages, photos, and voicemails out of any old iPhone backup — right on your own laptop. Nothing uploaded, nothing paid, nothing to sign up for.</p>
       <div class="hero__ctas">
-        <a class="btn btn--primary" href="#download">Download for Mac<span>· 48 MB</span></a>
+        <a class="btn btn--primary" href="https://github.com/charleswest775/openextract/releases/download/v0.4.0/OpenExtract-0.4.0-arm64.dmg">Download for Mac<span>· 144 MB</span></a>
         <a class="btn btn--ghost" href="#download">Windows &amp; Linux →</a>
       </div>
       <div class="hero__social">
@@ -364,17 +364,17 @@
         <h2>Get your <span class="it it--coral">memories</span> back.</h2>
         <p class="final-cta__lede">Download OpenExtract, point it at a backup, and see what's in there. Takes about two minutes.</p>
         <div class="final-cta__grid">
-          <a class="dl-card dl-card--primary" href="https://github.com/charleswest775/openextract/releases">
+          <a class="dl-card dl-card--primary" href="https://github.com/charleswest775/openextract/releases/download/v0.4.0/OpenExtract-0.4.0-arm64.dmg">
             <div class="dl-card__os">Download for macOS</div>
-            <div class="dl-card__meta">48 MB · Apple Silicon</div>
+            <div class="dl-card__meta">144 MB · Apple Silicon</div>
           </a>
-          <a class="dl-card" href="https://github.com/charleswest775/openextract/releases">
+          <a class="dl-card" href="https://github.com/charleswest775/openextract/releases/download/v0.4.0/OpenExtract-Setup-0.4.0.exe">
             <div class="dl-card__os">Download for Windows</div>
-            <div class="dl-card__meta">56 MB · 10 &amp; 11</div>
+            <div class="dl-card__meta">175 MB · 10 &amp; 11</div>
           </a>
-          <a class="dl-card" href="https://github.com/charleswest775/openextract/releases">
+          <a class="dl-card" href="https://github.com/charleswest775/openextract/releases/download/v0.4.0/OpenExtract-0.4.0.AppImage">
             <div class="dl-card__os">Download for Linux</div>
-            <div class="dl-card__meta">46 MB · AppImage</div>
+            <div class="dl-card__meta">176 MB · AppImage</div>
           </a>
         </div>
         <div class="final-cta__brew">or: <code>brew install openextract</code></div>


### PR DESCRIPTION
## Summary

The six "Download for <OS>" links on the homepage and how-it-works page all pointed at `/releases` (a listing page), not at the actual installer asset. Users had to manually click through and pick the right file.

Each link now goes directly at the v0.4.0 asset for that platform:

- macOS → `OpenExtract-0.4.0-arm64.dmg` (144 MB, Apple Silicon)
- Windows → `OpenExtract-Setup-0.4.0.exe` (175 MB)
- Linux → `OpenExtract-0.4.0.AppImage` (176 MB)

Sizes previously advertised (48/56/46 MB) were stale and have been refreshed to match the real assets.

## Maintenance note

URLs pin to `v0.4.0`. They'll need updating on each release until we either:
- Add Vercel rewrites (`/download/mac` → current asset URL), or
- Have the release workflow create stable-named aliases (`OpenExtract-latest-arm64.dmg`, etc.)

## Test plan

- [x] All three installer URLs return 200
- [ ] Vercel preview builds
- [ ] Clicking each card on the preview actually downloads the correct installer

🤖 Generated with [Claude Code](https://claude.com/claude-code)