### PR TITLE
Hearth redesign + organic loading indicators

### DIFF
--- a/mockups/app/OpenExtract App Mockups.html
+++ b/mockups/app/OpenExtract App Mockups.html
@@ -1,0 +1,203 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>OpenExtract — App UI Directions</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Geist:wght@300;400;500;600;700&family=Instrument+Serif:ital@0;1&family=IBM+Plex+Mono:wght@400;500&family=Fraunces:opsz,wght@9..144,300;9..144,400;9..144,500;9..144,600;9..144,700&family=Inter:wght@300;400;500;600;700&family=JetBrains+Mono:wght@400;500&family=Newsreader:ital,opsz,wght@0,6..72,400;0,6..72,500;0,6..72,600;1,6..72,400&display=swap" rel="stylesheet">
+  <style>
+    html, body { margin: 0; padding: 0; }
+    body { font-family: 'Geist', system-ui, sans-serif; background: #0e0e10; color: #e8e8ea; }
+    * { box-sizing: border-box; }
+    button { font-family: inherit; cursor: pointer; }
+
+    /* Variant chrome */
+    .chrome {
+      position: sticky; top: 0; z-index: 50;
+      display: flex; align-items: center; justify-content: space-between;
+      padding: 14px 22px;
+      background: #0b0b0d;
+      border-bottom: 1px solid #1f1f22;
+    }
+    .chrome-brand {
+      display: flex; align-items: baseline; gap: 10px;
+      font-family: 'Geist', sans-serif;
+    }
+    .chrome-brand .mark {
+      font-size: 13px; font-weight: 600; letter-spacing: -0.01em;
+    }
+    .chrome-brand .sub {
+      font-size: 11px; color: #8a8a92; letter-spacing: 0.02em;
+    }
+    .chrome-tabs {
+      display: flex; gap: 4px;
+      background: #161619; border: 1px solid #24242a; border-radius: 999px;
+      padding: 3px;
+    }
+    .chrome-tab {
+      background: transparent; border: 0; color: #8a8a92;
+      padding: 7px 14px; border-radius: 999px;
+      font-size: 12px; font-weight: 500; letter-spacing: 0.01em;
+      transition: color .18s, background .18s;
+    }
+    .chrome-tab:hover { color: #d7d7dc; }
+    .chrome-tab.active { background: #2a2a30; color: #fff; }
+    .chrome-tab .swatch {
+      display: inline-block; width: 8px; height: 8px; border-radius: 2px;
+      margin-right: 8px; vertical-align: middle;
+      transform: translateY(-1px);
+    }
+    .chrome-sub {
+      display: flex; align-items: center; gap: 10px;
+      font-size: 11px; color: #8a8a92;
+    }
+    .chrome-sub .screen-switch {
+      display: flex; gap: 2px; background: #161619; border: 1px solid #24242a;
+      border-radius: 8px; padding: 2px;
+    }
+    .chrome-sub .screen-switch button {
+      background: transparent; border: 0; color: #8a8a92;
+      padding: 5px 10px; border-radius: 6px; font-size: 11px;
+    }
+    .chrome-sub .screen-switch button.active { background: #2a2a30; color: #fff; }
+
+    /* Stage — the canvas behind the app window */
+    .stage {
+      min-height: calc(100vh - 57px);
+      display: flex; align-items: flex-start; justify-content: center;
+      padding: 28px;
+    }
+    .stage-inner {
+      width: 1360px; max-width: 100%;
+    }
+    .app-frame {
+      width: 100%;
+      border-radius: 14px;
+      overflow: hidden;
+      box-shadow: 0 30px 80px rgba(0,0,0,.5), 0 0 0 1px rgba(255,255,255,.04);
+      aspect-ratio: 16 / 10.2;
+    }
+
+    /* Variant-bg colors for the stage behind each frame */
+    .stage[data-variant="almanac"] { background: #1a1613; }
+    .stage[data-variant="hearth"]  { background: #1a1410; }
+    .stage[data-variant="studio"]  { background: #0d0b10; }
+    .stage[data-variant="linen"]   { background: #111112; }
+    .stage[data-variant="ledger"]    { background: #10141a; }
+    .stage[data-variant="garden"]    { background: #141612; }
+    .stage[data-variant="porcelain"] { background: #0d1018; }
+    .stage[data-variant="atelier"]   { background: #181612; }
+
+    /* Universal mac traffic lights */
+    .tl { display: flex; gap: 7px; }
+    .tl span { width: 12px; height: 12px; border-radius: 50%; display: inline-block; }
+    .tl .r { background: #ff5f57; }
+    .tl .y { background: #febc2e; }
+    .tl .g { background: #28c840; }
+
+    /* Hide scrollbars inside variants for cleaner mockups */
+    .variant-root ::-webkit-scrollbar { width: 0; height: 0; }
+  </style>
+  <script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+  <script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+  <script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+  <script type="text/babel" src="app-mockups/data.jsx"></script>
+  <script type="text/babel" src="app-mockups/icons.jsx"></script>
+  <script type="text/babel" src="app-mockups/almanac.jsx"></script>
+  <script type="text/babel" src="app-mockups/hearth.jsx"></script>
+  <script type="text/babel" src="app-mockups/studio.jsx"></script>
+  <script type="text/babel" src="app-mockups/linen.jsx"></script>
+  <script type="text/babel" src="app-mockups/shared-screens.jsx"></script>
+  <script type="text/babel" src="app-mockups/ledger.jsx"></script>
+  <script type="text/babel" src="app-mockups/garden.jsx"></script>
+  <script type="text/babel" src="app-mockups/porcelain.jsx"></script>
+  <script type="text/babel" src="app-mockups/atelier.jsx"></script>
+</head>
+<body>
+  <div id="root"></div>
+  <script type="text/babel">
+    const VARIANTS = [
+      { id: "almanac",   name: "Almanac",   desc: "Field journal · warm paper",    swatch: "#c85a3a" },
+      { id: "hearth",    name: "Hearth",    desc: "Photo album · dusk palette",    swatch: "#d97757" },
+      { id: "studio",    name: "Studio",    desc: "Editorial · deep plum + peach", swatch: "#f0a07a" },
+      { id: "linen",     name: "Linen",     desc: "Quiet minimal · muted blue",    swatch: "#4a6b8c" },
+      { id: "ledger",    name: "Ledger",    desc: "Cool off-white · teal",         swatch: "#2d7d7a" },
+      { id: "garden",    name: "Garden",    desc: "Soft pastels · organic",        swatch: "#8aa87a" },
+      { id: "porcelain", name: "Porcelain", desc: "Near-white · ultramarine",      swatch: "#2848c8" },
+      { id: "atelier",   name: "Atelier",   desc: "Greige · architectural",        swatch: "#7a6a52" },
+    ];
+    const SCREENS = [
+      { id: "backup",    label: "Backup" },
+      { id: "timeline",  label: "Timeline" },
+      { id: "messages",  label: "Messages" },
+      { id: "photos",    label: "Photos" },
+      { id: "voicemail", label: "Voicemail" },
+      { id: "calls",     label: "Calls" },
+      { id: "contacts",  label: "Contacts" },
+      { id: "notes",     label: "Notes" },
+    ];
+
+    const App = () => {
+      const [variant, setVariant] = React.useState("hearth");
+      const [screen, setScreen]   = React.useState("backup");
+      const current = VARIANTS.find(v => v.id === variant);
+
+      const Root = ({
+        almanac:   window.AlmanacRoot,
+        hearth:    window.HearthRoot,
+        studio:    window.StudioRoot,
+        linen:     window.LinenRoot,
+        ledger:    window.LedgerRoot,
+        garden:    window.GardenRoot,
+        porcelain: window.PorcelainRoot,
+        atelier:   window.AtelierRoot,
+      })[variant];
+
+      return (
+        <div>
+          <header className="chrome" data-screen-label={`00 Switcher · ${current.name}`}>
+            <div className="chrome-brand">
+              <div className="mark">OpenExtract</div>
+              <div className="sub">· 4 UI directions · app screens</div>
+            </div>
+            <div className="chrome-tabs">
+              {VARIANTS.map(v => (
+                <button key={v.id}
+                        className={`chrome-tab ${v.id === variant ? "active" : ""}`}
+                        onClick={() => setVariant(v.id)}>
+                  <span className="swatch" style={{ background: v.swatch }}></span>
+                  {v.name}
+                </button>
+              ))}
+            </div>
+            <div className="chrome-sub">
+              <span>{current.desc}</span>
+              <div className="screen-switch">
+                {SCREENS.map(s => (
+                  <button key={s.id}
+                          className={s.id === screen ? "active" : ""}
+                          onClick={() => setScreen(s.id)}>
+                    {s.label}
+                  </button>
+                ))}
+              </div>
+            </div>
+          </header>
+
+          <div className="stage" data-variant={variant} data-screen-label={`${current.name} · ${screen}`}>
+            <div className="stage-inner">
+              <div className="app-frame variant-root">
+                {Root ? <Root screen={screen} /> : <div style={{ padding: 40 }}>Loading {variant}…</div>}
+              </div>
+            </div>
+          </div>
+        </div>
+      );
+    };
+
+    ReactDOM.createRoot(document.getElementById("root")).render(<App />);
+  </script>
+</body>
+</html>

--- a/mockups/app/app-mockups/almanac.jsx
+++ b/mockups/app/app-mockups/almanac.jsx
@@ -1,0 +1,566 @@
+// ======================================================================
+// ALMANAC — Field journal aesthetic
+// Warm paper #f6eee4, ink #201a15, terracotta #c85a3a accent.
+// Instrument Serif display, Geist body, IBM Plex Mono for data.
+// Novel UX: backups shown as a ledger on a vertical time-rail;
+// messages view has a right-margin annotation rail with dated callouts.
+// ======================================================================
+
+const A_TOKENS = {
+  paper:    "#f6eee4",
+  paperAlt: "#efe5d5",
+  ink:      "#201a15",
+  ink2:     "#5a4f46",
+  ink3:     "#8f8475",
+  rule:     "#d9ccb7",
+  ruleSoft: "#e6dcc8",
+  accent:   "#c85a3a",
+  accent2:  "#8a7a5a",
+  accent3:  "#e6b070",
+  bubbleMe: "#201a15",   // ink bubble for outgoing
+  bubbleThem: "#ece1cd", // warm card for incoming
+};
+
+const A_FONTS = {
+  serif: "'Instrument Serif', 'Newsreader', serif",
+  sans:  "'Geist', system-ui, sans-serif",
+  mono:  "'IBM Plex Mono', ui-monospace, monospace",
+};
+
+const Almanac_Chrome = ({ children, title, subtitle, right }) => (
+  <div style={{
+    background: A_TOKENS.paper, color: A_TOKENS.ink, height: "100%",
+    fontFamily: A_FONTS.sans, display: "flex", flexDirection: "column"
+  }}>
+    {/* Title bar — mac traffic lights + wordmark */}
+    <div style={{
+      height: 44, display: "flex", alignItems: "center", padding: "0 16px",
+      borderBottom: `1px solid ${A_TOKENS.ruleSoft}`, flexShrink: 0,
+      background: A_TOKENS.paper,
+    }}>
+      <div className="tl"><span className="r"/><span className="y"/><span className="g"/></div>
+      <div style={{
+        marginLeft: 16, fontFamily: A_FONTS.serif, fontSize: 18,
+        letterSpacing: "-0.01em", fontWeight: 400,
+      }}>
+        Open<span style={{ fontStyle: "italic", color: A_TOKENS.accent }}>Extract</span>
+      </div>
+      <div style={{ flex: 1 }} />
+      <div style={{ fontFamily: A_FONTS.mono, fontSize: 10.5, color: A_TOKENS.ink3, letterSpacing: "0.04em" }}>
+        VOL. I · No. 3 · {new Date().toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" })}
+      </div>
+    </div>
+    {children}
+  </div>
+);
+
+const Almanac_Sidebar = ({ active = "messages" }) => {
+  const Icons = window.OEIcons;
+  const items = [
+    { id: "timeline",  label: "Timeline",  count: "—",      I: Icons.Clock },
+    { id: "messages",  label: "Messages",  count: "48,213", I: Icons.Message },
+    { id: "photos",    label: "Photos",    count: "12,847", I: Icons.Image },
+    { id: "voicemail", label: "Voicemail", count: "24",     I: Icons.Voicemail },
+    { id: "calls",     label: "Calls",     count: "4,281",  I: Icons.Phone },
+    { id: "contacts",  label: "Contacts",  count: "612",    I: Icons.User },
+    { id: "notes",     label: "Notes",     count: "189",    I: Icons.FileText },
+  ];
+  return (
+    <nav style={{
+      width: 220, flexShrink: 0, padding: "18px 14px",
+      borderRight: `1px solid ${A_TOKENS.ruleSoft}`,
+      background: A_TOKENS.paperAlt,
+    }}>
+      <div style={{
+        fontFamily: A_FONTS.mono, fontSize: 10, letterSpacing: "0.14em",
+        color: A_TOKENS.ink3, textTransform: "uppercase", padding: "6px 8px 10px",
+      }}>§ Contents</div>
+      {items.map((it, i) => {
+        const I = it.I;
+        const on = it.id === active;
+        return (
+          <div key={it.id} style={{
+            display: "flex", alignItems: "center", gap: 10,
+            padding: "8px 10px", borderRadius: 6,
+            background: on ? A_TOKENS.paper : "transparent",
+            color: on ? A_TOKENS.ink : A_TOKENS.ink2,
+            position: "relative", cursor: "pointer",
+            borderLeft: on ? `2px solid ${A_TOKENS.accent}` : "2px solid transparent",
+            marginLeft: on ? 0 : 2,
+          }}>
+            <I size={15} strokeWidth={1.5} stroke={on ? A_TOKENS.accent : A_TOKENS.ink2} />
+            <span style={{
+              fontSize: 13, fontWeight: on ? 500 : 400, letterSpacing: "-0.005em",
+              flex: 1,
+            }}>{it.label}</span>
+            <span style={{ fontFamily: A_FONTS.mono, fontSize: 10, color: A_TOKENS.ink3 }}>
+              {it.count}
+            </span>
+          </div>
+        );
+      })}
+      <div style={{
+        marginTop: 22, padding: "12px", borderTop: `1px dashed ${A_TOKENS.rule}`,
+        fontFamily: A_FONTS.serif, fontSize: 14, fontStyle: "italic",
+        color: A_TOKENS.ink2, lineHeight: 1.35,
+      }}>
+        “Nothing leaves this machine.”
+        <div style={{ fontFamily: A_FONTS.mono, fontSize: 9.5, color: A_TOKENS.ink3, letterSpacing: "0.1em", marginTop: 6 }}>
+          — LOCAL · OFFLINE · OPEN SOURCE
+        </div>
+      </div>
+    </nav>
+  );
+};
+
+// ------ BACKUP SELECTOR: ledger on a vertical time-rail ------
+const Almanac_Backup = () => {
+  const backups = window.OE_DATA.backups;
+  const Icons = window.OEIcons;
+
+  return (
+    <div style={{
+      flex: 1, display: "flex", flexDirection: "column",
+      background: A_TOKENS.paper, overflow: "auto",
+    }}>
+      {/* Masthead */}
+      <div style={{ padding: "44px 64px 28px" }}>
+        <div style={{
+          fontFamily: A_FONTS.mono, fontSize: 10, letterSpacing: "0.18em",
+          color: A_TOKENS.ink3, textTransform: "uppercase",
+        }}>§ 01 — Choose a backup</div>
+        <h1 style={{
+          fontFamily: A_FONTS.serif, fontSize: 64, lineHeight: 1.02, margin: "10px 0 8px",
+          fontWeight: 400, letterSpacing: "-0.02em",
+        }}>
+          Three <span style={{ fontStyle: "italic", color: A_TOKENS.accent }}>time capsules</span><br/>
+          found on this Mac.
+        </h1>
+        <p style={{
+          maxWidth: 640, fontSize: 14.5, lineHeight: 1.55, color: A_TOKENS.ink2,
+          margin: "6px 0 0",
+        }}>
+          We looked in <span style={{ fontFamily: A_FONTS.mono, fontSize: 12 }}>~/Library/Application Support/MobileSync</span> and
+          cross-referenced Finder's index. Pick a backup to open — we'll read it here, never upload anything.
+        </p>
+      </div>
+
+      {/* Ledger */}
+      <div style={{ padding: "0 64px 44px", position: "relative" }}>
+        {/* Column header */}
+        <div style={{
+          display: "grid", gridTemplateColumns: "90px 1fr 200px 180px 140px",
+          gap: 18, padding: "10px 0 12px",
+          borderBottom: `1px solid ${A_TOKENS.rule}`,
+          fontFamily: A_FONTS.mono, fontSize: 9.5, letterSpacing: "0.14em",
+          color: A_TOKENS.ink3, textTransform: "uppercase",
+        }}>
+          <div>Year</div>
+          <div>Device</div>
+          <div>What's inside</div>
+          <div>Size · Encryption</div>
+          <div style={{ textAlign: "right" }}>—</div>
+        </div>
+
+        {/* Entries */}
+        {backups.map((b, i) => {
+          const year = b.lastBackup.match(/\d{4}/)[0];
+          const featured = i === 0;
+          return (
+            <div key={b.id} style={{
+              display: "grid", gridTemplateColumns: "90px 1fr 200px 180px 140px",
+              gap: 18, alignItems: "stretch",
+              padding: "22px 0",
+              borderBottom: `1px solid ${A_TOKENS.ruleSoft}`,
+              position: "relative",
+            }}>
+              {/* Year — huge numeral */}
+              <div style={{
+                fontFamily: A_FONTS.serif, fontSize: 48, lineHeight: 1,
+                fontWeight: 400, color: featured ? A_TOKENS.accent : A_TOKENS.ink,
+                letterSpacing: "-0.02em",
+              }}>
+                {year}
+                <div style={{
+                  fontFamily: A_FONTS.mono, fontSize: 10, color: A_TOKENS.ink3,
+                  letterSpacing: "0.06em", marginTop: 4,
+                }}>{b.relative}</div>
+              </div>
+
+              {/* Device */}
+              <div>
+                <div style={{
+                  fontFamily: A_FONTS.serif, fontSize: 26, lineHeight: 1.1,
+                  fontWeight: 400, letterSpacing: "-0.01em",
+                }}>{b.device}</div>
+                <div style={{
+                  fontSize: 13, color: A_TOKENS.ink2, marginTop: 4,
+                  fontStyle: "italic", fontFamily: A_FONTS.serif,
+                }}>“{b.owner}”</div>
+                <div style={{
+                  fontFamily: A_FONTS.mono, fontSize: 10.5, color: A_TOKENS.ink3,
+                  letterSpacing: "0.04em", marginTop: 8,
+                }}>
+                  {b.ios.toUpperCase()} · {b.color.toUpperCase()} · {b.lastBackup.toUpperCase()}
+                </div>
+              </div>
+
+              {/* Contents — compact item bars */}
+              <div style={{ display: "flex", flexDirection: "column", gap: 5, fontSize: 12, color: A_TOKENS.ink2 }}>
+                {[
+                  ["Messages", b.messages],
+                  ["Photos",   b.photos],
+                  ["Contacts", b.contacts],
+                  ["Calls",    b.calls],
+                ].map(([k, v]) => (
+                  <div key={k} style={{ display: "flex", justifyContent: "space-between", gap: 8 }}>
+                    <span>{k}</span>
+                    <span style={{ fontFamily: A_FONTS.mono, fontSize: 11.5, color: A_TOKENS.ink }}>
+                      {v.toLocaleString()}
+                    </span>
+                  </div>
+                ))}
+              </div>
+
+              {/* Size + encryption */}
+              <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+                <div style={{
+                  fontFamily: A_FONTS.serif, fontSize: 22, fontWeight: 400,
+                }}>{b.size}</div>
+                <div style={{
+                  display: "inline-flex", alignItems: "center", gap: 6,
+                  fontSize: 11.5, color: b.encrypted ? A_TOKENS.accent : A_TOKENS.ink2,
+                  background: b.encrypted ? "rgba(200,90,58,.08)" : "rgba(138,122,90,.10)",
+                  padding: "4px 9px", borderRadius: 999, alignSelf: "flex-start",
+                  border: `1px solid ${b.encrypted ? "rgba(200,90,58,.28)" : "rgba(138,122,90,.22)"}`,
+                }}>
+                  <Icons.Lock size={11} strokeWidth={1.7} />
+                  {b.encrypted ? "Encrypted · password needed" : "Unencrypted"}
+                </div>
+                <div style={{
+                  fontFamily: A_FONTS.mono, fontSize: 9.5, color: A_TOKENS.ink3,
+                  letterSpacing: "0.08em", marginTop: 4,
+                }}>
+                  UDID {b.id.toUpperCase().replace("-", "·")}
+                </div>
+              </div>
+
+              {/* Action */}
+              <div style={{ display: "flex", alignItems: "center", justifyContent: "flex-end" }}>
+                <button style={{
+                  background: featured ? A_TOKENS.ink : "transparent",
+                  color: featured ? A_TOKENS.paper : A_TOKENS.ink,
+                  border: `1px solid ${featured ? A_TOKENS.ink : A_TOKENS.rule}`,
+                  borderRadius: 999, padding: "10px 18px",
+                  fontFamily: A_FONTS.sans, fontSize: 12.5, fontWeight: 500,
+                  letterSpacing: "-0.005em",
+                  display: "inline-flex", alignItems: "center", gap: 8,
+                }}>
+                  Open
+                  <Icons.ArrowRight size={13} strokeWidth={1.7} />
+                </button>
+              </div>
+            </div>
+          );
+        })}
+
+        {/* Add backup */}
+        <div style={{
+          marginTop: 18, padding: "20px 22px",
+          border: `1px dashed ${A_TOKENS.rule}`, borderRadius: 6,
+          display: "flex", alignItems: "center", gap: 14,
+          color: A_TOKENS.ink2, fontSize: 13,
+        }}>
+          <Icons.Plus size={16} strokeWidth={1.6} stroke={A_TOKENS.ink2} />
+          Don't see yours? Point OpenExtract at a folder —
+          <span style={{ fontFamily: A_FONTS.mono, fontSize: 11.5 }}>File ▸ Open backup folder…</span>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+// ------ MESSAGES with right-margin annotation rail ------
+const Almanac_Messages = () => {
+  const { conversations, activeThread, marginalia } = window.OE_DATA;
+  const Icons = window.OEIcons;
+
+  return (
+    <div style={{ flex: 1, display: "flex", minWidth: 0, background: A_TOKENS.paper, overflow: "hidden" }}>
+      <Almanac_Sidebar active="messages" />
+
+      {/* Conversation list */}
+      <aside style={{
+        width: 270, flexShrink: 0, borderRight: `1px solid ${A_TOKENS.ruleSoft}`,
+        display: "flex", flexDirection: "column",
+      }}>
+        <div style={{ padding: "18px 18px 10px" }}>
+          <div style={{ fontFamily: A_FONTS.mono, fontSize: 10, letterSpacing: "0.14em", color: A_TOKENS.ink3, textTransform: "uppercase" }}>
+            § Messages
+          </div>
+          <div style={{ fontFamily: A_FONTS.serif, fontSize: 26, lineHeight: 1.1, marginTop: 4 }}>
+            214 threads
+          </div>
+          <div style={{
+            marginTop: 12, display: "flex", alignItems: "center", gap: 8,
+            background: A_TOKENS.paperAlt, border: `1px solid ${A_TOKENS.ruleSoft}`,
+            borderRadius: 6, padding: "7px 10px",
+          }}>
+            <Icons.Search size={13} strokeWidth={1.5} stroke={A_TOKENS.ink3} />
+            <span style={{ fontSize: 12, color: A_TOKENS.ink3 }}>Search conversations</span>
+          </div>
+        </div>
+        <div style={{ overflow: "auto", flex: 1, padding: "0 8px 12px" }}>
+          {conversations.map((c) => {
+            const on = c.id === activeThread.contactId;
+            return (
+              <div key={c.id} style={{
+                display: "flex", gap: 11, padding: "10px 10px", borderRadius: 6,
+                background: on ? A_TOKENS.paperAlt : "transparent",
+                borderLeft: on ? `2px solid ${A_TOKENS.accent}` : "2px solid transparent",
+                marginLeft: on ? 0 : 2,
+                cursor: "pointer",
+              }}>
+                <div style={{
+                  width: 34, height: 34, borderRadius: "50%", flexShrink: 0,
+                  background: `oklch(78% 0.06 ${c.avatarHue})`,
+                  display: "flex", alignItems: "center", justifyContent: "center",
+                  fontFamily: A_FONTS.serif, fontSize: 15, color: A_TOKENS.ink,
+                  border: `1px solid ${A_TOKENS.rule}`,
+                }}>
+                  {c.name[0]}
+                </div>
+                <div style={{ flex: 1, minWidth: 0 }}>
+                  <div style={{ display: "flex", justifyContent: "space-between", alignItems: "baseline" }}>
+                    <span style={{ fontSize: 13.5, fontWeight: on ? 500 : 400, color: A_TOKENS.ink, letterSpacing: "-0.005em" }}>
+                      {c.name}
+                    </span>
+                    <span style={{ fontFamily: A_FONTS.mono, fontSize: 10, color: A_TOKENS.ink3 }}>
+                      {c.time}
+                    </span>
+                  </div>
+                  <div style={{
+                    fontSize: 12.5, color: A_TOKENS.ink2, marginTop: 2,
+                    whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis",
+                  }}>
+                    {c.preview}
+                  </div>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      </aside>
+
+      {/* Conversation body */}
+      <section style={{ flex: 1, display: "flex", flexDirection: "column", minWidth: 0, background: A_TOKENS.paper }}>
+        {/* Thread header */}
+        <div style={{
+          padding: "20px 28px 16px", borderBottom: `1px solid ${A_TOKENS.ruleSoft}`,
+          display: "flex", alignItems: "flex-start", gap: 14,
+        }}>
+          <div style={{
+            width: 44, height: 44, borderRadius: "50%", flexShrink: 0,
+            background: "oklch(78% 0.06 14)", border: `1px solid ${A_TOKENS.rule}`,
+            display: "flex", alignItems: "center", justifyContent: "center",
+            fontFamily: A_FONTS.serif, fontSize: 20,
+          }}>E</div>
+          <div style={{ flex: 1 }}>
+            <div style={{ fontFamily: A_FONTS.serif, fontSize: 28, lineHeight: 1, fontWeight: 400 }}>
+              Emma
+            </div>
+            <div style={{
+              fontFamily: A_FONTS.mono, fontSize: 10.5, letterSpacing: "0.06em",
+              color: A_TOKENS.ink3, marginTop: 6, textTransform: "uppercase",
+            }}>
+              Daughter · 847 messages · 2016–2023
+            </div>
+          </div>
+          <button style={{
+            background: "transparent", border: `1px solid ${A_TOKENS.rule}`,
+            color: A_TOKENS.ink, padding: "7px 14px", borderRadius: 999,
+            fontSize: 12, display: "inline-flex", alignItems: "center", gap: 7,
+          }}>
+            <Icons.Export size={13} strokeWidth={1.6} />
+            Export thread
+          </button>
+        </div>
+
+        {/* Thread + margin rail */}
+        <div style={{ flex: 1, overflow: "auto", display: "grid", gridTemplateColumns: "1fr 220px", gap: 0 }}>
+          <div style={{ padding: "22px 28px 18px 28px", position: "relative" }}>
+            {/* Date divider */}
+            <div style={{ display: "flex", alignItems: "center", gap: 10, margin: "0 0 18px" }}>
+              <div style={{ flex: 1, height: 1, background: A_TOKENS.ruleSoft }}/>
+              <div style={{
+                fontFamily: A_FONTS.mono, fontSize: 10, letterSpacing: "0.14em",
+                color: A_TOKENS.ink3, textTransform: "uppercase",
+              }}>Monday · Aug 14, 2023</div>
+              <div style={{ flex: 1, height: 1, background: A_TOKENS.ruleSoft }}/>
+            </div>
+
+            {activeThread.messages.map((m) => {
+              const mine = m.from === "me";
+              const anno = marginalia.find(x => x.anchorId === m.id);
+              return (
+                <div key={m.id} id={`am-msg-${m.id}`}
+                     style={{
+                       display: "flex", justifyContent: mine ? "flex-end" : "flex-start",
+                       marginBottom: 10,
+                     }}>
+                  <div style={{
+                    maxWidth: "68%",
+                    background: mine ? A_TOKENS.bubbleMe : A_TOKENS.bubbleThem,
+                    color: mine ? A_TOKENS.paper : A_TOKENS.ink,
+                    padding: m.kind === "photo" ? 8 : "9px 14px",
+                    borderRadius: 14,
+                    border: mine ? "none" : `1px solid ${A_TOKENS.rule}`,
+                    fontSize: 14, lineHeight: 1.4, letterSpacing: "-0.005em",
+                  }}>
+                    {m.kind === "photo" ? (
+                      <div>
+                        <div style={{
+                          width: 260, height: 180, borderRadius: 8,
+                          background: `repeating-linear-gradient(135deg, #d9c6a8 0 10px, #cdb996 10px 20px)`,
+                          position: "relative", overflow: "hidden",
+                          border: `1px solid ${A_TOKENS.rule}`,
+                        }}>
+                          <div style={{
+                            position: "absolute", inset: 0,
+                            background: "linear-gradient(180deg, rgba(0,0,0,0) 40%, rgba(0,0,0,.35))",
+                          }}/>
+                          <div style={{
+                            position: "absolute", left: 10, bottom: 8, right: 10,
+                            fontFamily: A_FONTS.mono, fontSize: 10, color: "#fff8ec",
+                            letterSpacing: "0.04em",
+                          }}>
+                            [IMG_{String(m.id).padStart(4, "0")}] · {m.caption}
+                          </div>
+                        </div>
+                        <div style={{
+                          marginTop: 6, fontFamily: A_FONTS.mono, fontSize: 10,
+                          color: A_TOKENS.ink3, letterSpacing: "0.04em",
+                        }}>{m.time}</div>
+                      </div>
+                    ) : (
+                      <>
+                        <div>{m.text}</div>
+                        <div style={{
+                          marginTop: 4, fontFamily: A_FONTS.mono, fontSize: 10,
+                          color: mine ? "rgba(246,238,228,.45)" : A_TOKENS.ink3,
+                          textAlign: mine ? "right" : "left",
+                          letterSpacing: "0.04em",
+                        }}>{m.time}</div>
+                      </>
+                    )}
+                  </div>
+                </div>
+              );
+            })}
+
+            {/* Composer-ish read-only row */}
+            <div style={{
+              marginTop: 18, padding: "10px 14px",
+              background: A_TOKENS.paperAlt, border: `1px dashed ${A_TOKENS.rule}`,
+              borderRadius: 8, fontSize: 12, color: A_TOKENS.ink3,
+              fontStyle: "italic", fontFamily: A_FONTS.serif,
+            }}>
+              Read-only — OpenExtract never sends messages. This is the record as it was on Aug 14, 2023.
+            </div>
+          </div>
+
+          {/* Annotation rail — the novel bit */}
+          <div style={{
+            borderLeft: `1px dashed ${A_TOKENS.rule}`,
+            padding: "22px 20px 18px 22px",
+            background: "linear-gradient(180deg, transparent, rgba(217,204,183,.10))",
+          }}>
+            <div style={{
+              fontFamily: A_FONTS.mono, fontSize: 9.5, letterSpacing: "0.16em",
+              color: A_TOKENS.ink3, textTransform: "uppercase", marginBottom: 12,
+            }}>
+              Marginalia
+            </div>
+            {marginalia.map((a) => (
+              <div key={a.anchorId} style={{
+                marginBottom: 16, paddingLeft: 12,
+                borderLeft: `2px solid ${A_TOKENS.accent}`,
+              }}>
+                <div style={{
+                  fontFamily: A_FONTS.serif, fontSize: 15, lineHeight: 1.25,
+                  fontStyle: "italic", color: A_TOKENS.ink,
+                }}>
+                  {a.label}
+                </div>
+                <div style={{
+                  fontSize: 12, color: A_TOKENS.ink2, marginTop: 4, lineHeight: 1.4,
+                }}>
+                  {a.note}
+                </div>
+              </div>
+            ))}
+
+            <div style={{
+              marginTop: 24, paddingTop: 16,
+              borderTop: `1px dashed ${A_TOKENS.rule}`,
+              fontSize: 11.5, color: A_TOKENS.ink3, lineHeight: 1.5,
+            }}>
+              <span style={{ fontFamily: A_FONTS.mono, fontSize: 10, letterSpacing: "0.14em", textTransform: "uppercase" }}>
+                Filters
+              </span>
+              <div style={{ marginTop: 8, display: "flex", flexWrap: "wrap", gap: 6 }}>
+                {["3mo", "6mo", "This year", "All time", "Photos only"].map((f, i) => (
+                  <span key={f} style={{
+                    padding: "4px 10px", fontSize: 11, borderRadius: 999,
+                    border: `1px solid ${i === 3 ? A_TOKENS.ink : A_TOKENS.rule}`,
+                    color: i === 3 ? A_TOKENS.paper : A_TOKENS.ink2,
+                    background: i === 3 ? A_TOKENS.ink : "transparent",
+                  }}>{f}</span>
+                ))}
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+};
+
+window.AlmanacRoot = ({ screen }) => {
+  if (screen === "backup") {
+    return (
+      <Almanac_Chrome>
+        <div style={{ flex: 1, display: "flex", minHeight: 0 }}>
+          <Almanac_Sidebar active="" />
+          <Almanac_Backup />
+        </div>
+      </Almanac_Chrome>
+    );
+  }
+  if (screen === "messages") {
+    return (
+      <Almanac_Chrome>
+        <div style={{ flex: 1, display: "flex", minHeight: 0 }}>
+          <Almanac_Sidebar active="messages" />
+          <Almanac_Messages />
+        </div>
+      </Almanac_Chrome>
+    );
+  }
+  const tokens = {
+    bg: A_TOKENS.paper, surface: "#fffaf0", sunk: A_TOKENS.paperAlt,
+    ink: A_TOKENS.ink, ink2: A_TOKENS.ink2, ink3: A_TOKENS.ink3,
+    rule: A_TOKENS.ruleSoft, ruleStr: A_TOKENS.rule,
+    accent: A_TOKENS.accent, accentW: "#f4e0d2",
+    sans: A_FONTS.sans, serif: A_FONTS.serif, mono: A_FONTS.mono,
+    titleSerif: true, titleWeight: 400, titleLetter: "-0.02em", radius: 6,
+    bubbleMe: A_TOKENS.ink, bubbleThem: A_TOKENS.bubbleThem,
+    chipActive: A_TOKENS.ink, chipActiveFg: A_TOKENS.paper, chipFg: A_TOKENS.ink2,
+  };
+  return window.SharedScreens.render({
+    screen, tokens,
+    Sidebar: (p) => <Almanac_Sidebar active={screen}/>,
+    Chrome: Almanac_Chrome,
+    backupComponent: Almanac_Backup, messagesComponent: Almanac_Messages,
+  });
+};

--- a/mockups/app/app-mockups/atelier.jsx
+++ b/mockups/app/app-mockups/atelier.jsx
@@ -1,0 +1,481 @@
+// ======================================================================
+// ATELIER — Greige architectural. Strong grid, mono+serif duo.
+// Novel UX: Contacts as a blueprint node-map with call-frequency edges.
+// ======================================================================
+
+const AT = {
+  bg:       "#f5f2ec",
+  surface:  "#fbf9f3",
+  sunk:     "#ebe7dc",
+  ink:      "#201d18",
+  ink2:     "#54504a",
+  ink3:     "#8a867c",
+  rule:     "#ddd8cc",
+  ruleStr:  "#c9c3b4",
+  accent:   "#2b4a6a",  // drafting blue
+  accentW:  "#dfe7f0",
+  sans:     "'Inter', system-ui, sans-serif",
+  serif:    "'Fraunces', serif",
+  mono:     "'JetBrains Mono', monospace",
+  titleSerif: true,
+  titleWeight: 500,
+  titleLetter: "-0.02em",
+  radius:   2,
+  bubbleMe:  "#201d18",
+  bubbleThem:"#ebe7dc",
+  chipActive: "#201d18",
+  chipActiveFg: "#f5f2ec",
+  chipFg: "#54504a",
+};
+
+const AtelierChrome = ({ children }) => (
+  <div style={{
+    background: AT.bg, color: AT.ink, height: "100%",
+    fontFamily: AT.sans, display: "flex", flexDirection: "column",
+    // subtle grid paper
+    backgroundImage: `
+      linear-gradient(${AT.rule} 1px, transparent 1px),
+      linear-gradient(90deg, ${AT.rule} 1px, transparent 1px)
+    `,
+    backgroundSize: "40px 40px",
+    backgroundPosition: "-1px -1px",
+  }}>
+    <div style={{
+      height: 42, display: "flex", alignItems: "center", padding: "0 16px",
+      background: AT.bg, borderBottom: `1px solid ${AT.ruleStr}`, flexShrink: 0,
+    }}>
+      <div className="tl"><span className="r"/><span className="y"/><span className="g"/></div>
+      <div style={{ marginLeft: 16, fontFamily: AT.mono, fontSize: 12, fontWeight: 500,
+                     letterSpacing: "0.06em", textTransform: "uppercase" }}>
+        OpenExtract
+      </div>
+      <span style={{ width: 12, height: 1, background: AT.ruleStr, margin: "0 12px" }}/>
+      <span style={{ fontSize: 11, color: AT.ink2, fontFamily: AT.mono, letterSpacing: "0.04em" }}>
+        Dwg. 001 — Mom/iPhone 13 Pro/2023‑08‑14
+      </span>
+      <div style={{ flex: 1 }}/>
+      <span style={{ fontSize: 10, color: AT.ink3, fontFamily: AT.mono, letterSpacing: "0.14em",
+                      textTransform: "uppercase" }}>Scale 1:1 · Local</span>
+    </div>
+    {children}
+  </div>
+);
+
+const AtelierSidebar = ({ active }) => {
+  const Icons = window.OEIcons;
+  const items = [
+    { id: "timeline",  label: "Timeline",  I: Icons.Clock,     n: "01" },
+    { id: "messages",  label: "Messages",  I: Icons.Message,   n: "02" },
+    { id: "photos",    label: "Photos",    I: Icons.Image,     n: "03" },
+    { id: "voicemail", label: "Voicemail", I: Icons.Voicemail, n: "04" },
+    { id: "calls",     label: "Calls",     I: Icons.Phone,     n: "05" },
+    { id: "contacts",  label: "Contacts",  I: Icons.User,      n: "06" },
+    { id: "notes",     label: "Notes",     I: Icons.FileText,  n: "07" },
+  ];
+  return (
+    <nav style={{
+      width: 220, flexShrink: 0, padding: "16px 10px",
+      borderRight: `1px solid ${AT.ruleStr}`, background: AT.bg,
+      display: "flex", flexDirection: "column",
+    }}>
+      <div style={{ fontFamily: AT.mono, fontSize: 10, color: AT.ink3, letterSpacing: "0.14em",
+                    textTransform: "uppercase", padding: "4px 12px 12px", fontWeight: 600 }}>
+        Index
+      </div>
+      {items.map(it => {
+        const on = it.id === active;
+        const I = it.I;
+        return (
+          <div key={it.id} style={{
+            display: "grid", gridTemplateColumns: "24px 18px 1fr",
+            alignItems: "center", gap: 8, padding: "8px 12px",
+            cursor: "pointer",
+            background: on ? AT.accentW : "transparent",
+            borderLeft: on ? `2px solid ${AT.accent}` : "2px solid transparent",
+            marginLeft: on ? 0 : 2,
+            color: on ? AT.ink : AT.ink2,
+          }}>
+            <span style={{ fontFamily: AT.mono, fontSize: 10, color: AT.ink3, letterSpacing: "0.06em" }}>{it.n}</span>
+            <I size={14} strokeWidth={1.4} stroke={on ? AT.accent : AT.ink2}/>
+            <span style={{ fontSize: 13, fontWeight: on ? 600 : 400,
+                           fontFamily: AT.serif, letterSpacing: "-0.005em" }}>{it.label}</span>
+          </div>
+        );
+      })}
+      <div style={{ flex: 1 }}/>
+      <div style={{
+        fontFamily: AT.mono, fontSize: 10, color: AT.ink3,
+        padding: "10px 12px 4px", borderTop: `1px solid ${AT.ruleStr}`, marginTop: 10,
+        lineHeight: 1.6, letterSpacing: "0.04em",
+      }}>
+        DWG 001 — M.WHITFIELD<br/>
+        REV. 2023.08.14<br/>
+        SHT. — of 7
+      </div>
+    </nav>
+  );
+};
+
+const AtelierBackup = () => {
+  const backups = window.OE_DATA.backups;
+  const Icons = window.OEIcons;
+  return (
+    <div style={{ flex: 1, overflow: "auto", background: AT.bg }}>
+      <div style={{ padding: "48px 56px 14px" }}>
+        <div style={{ fontFamily: AT.mono, fontSize: 10, color: AT.accent, letterSpacing: "0.16em",
+                       textTransform: "uppercase", fontWeight: 600 }}>
+          ⎯ sheet 00 · source selection
+        </div>
+        <h1 style={{ margin: "12px 0 4px", fontFamily: AT.serif, fontWeight: 500,
+                      fontSize: 44, letterSpacing: "-0.025em", lineHeight: 1.05 }}>
+          Three backups on this Mac.
+        </h1>
+        <p style={{ margin: "6px 0 0", fontSize: 13.5, color: AT.ink2, lineHeight: 1.6, maxWidth: 560 }}>
+          Read-only. Drawing revisions are non-destructive.
+        </p>
+      </div>
+
+      <div style={{ padding: "0 56px 56px" }}>
+        {backups.map((b, i) => (
+          <div key={b.id} style={{
+            background: AT.surface,
+            border: `1px solid ${AT.ruleStr}`, marginTop: 16,
+            position: "relative",
+          }}>
+            {/* tick header */}
+            <div style={{
+              display: "flex", alignItems: "center",
+              padding: "6px 14px", borderBottom: `1px solid ${AT.ruleStr}`,
+              background: AT.sunk, fontFamily: AT.mono, fontSize: 10,
+              color: AT.ink3, letterSpacing: "0.14em", textTransform: "uppercase",
+            }}>
+              <span>Backup № 0{i+1}</span>
+              <span style={{ margin: "0 10px", color: AT.ruleStr }}>│</span>
+              <span>{b.ios}</span>
+              <span style={{ flex: 1 }}/>
+              <span>{b.lastBackup}</span>
+            </div>
+            <div style={{
+              display: "grid", gridTemplateColumns: "1.4fr 1fr 1fr 150px",
+              padding: "20px 20px", gap: 18, alignItems: "center",
+            }}>
+              <div>
+                <div style={{ fontFamily: AT.serif, fontSize: 26, fontWeight: 500, letterSpacing: "-0.02em" }}>{b.device}</div>
+                <div style={{ fontSize: 12.5, color: AT.ink2, marginTop: 2 }}>{b.owner}</div>
+              </div>
+              <div style={{ fontFamily: AT.mono, fontSize: 12, color: AT.ink2, lineHeight: 1.6 }}>
+                <div>PERIOD · {b.years[0]}–{b.years[b.years.length-1]}</div>
+                <div>SIZE ·&nbsp;&nbsp; {b.size}</div>
+                <div>ENC &nbsp;·&nbsp;&nbsp; {b.encrypted ? "YES" : "NO"}</div>
+              </div>
+              <div style={{ fontFamily: AT.mono, fontSize: 12, color: AT.ink2, lineHeight: 1.6 }}>
+                <div>MSG · {b.messages.toLocaleString()}</div>
+                <div>PHO · {b.photos.toLocaleString()}</div>
+                <div>CAL · {b.calls.toLocaleString()} / VM · {b.voicemails}</div>
+              </div>
+              <div style={{ display: "flex", justifyContent: "flex-end" }}>
+                <button style={{
+                  background: i === 0 ? AT.accent : "transparent",
+                  color: i === 0 ? "#fff" : AT.ink,
+                  border: `1px solid ${i === 0 ? AT.accent : AT.ruleStr}`,
+                  padding: "9px 16px", borderRadius: 2,
+                  fontSize: 12, fontFamily: AT.mono, letterSpacing: "0.08em",
+                  textTransform: "uppercase", fontWeight: 600,
+                  display: "inline-flex", gap: 6, alignItems: "center",
+                }}>
+                  Open <Icons.ArrowRight size={11} strokeWidth={2}/>
+                </button>
+              </div>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+const AtelierMessages = () => {
+  const { conversations, activeThread } = window.OE_DATA;
+  const Icons = window.OEIcons;
+
+  return (
+    <div style={{ flex: 1, display: "flex", background: AT.bg, minWidth: 0 }}>
+      <aside style={{
+        width: 276, flexShrink: 0, borderRight: `1px solid ${AT.ruleStr}`,
+        display: "flex", flexDirection: "column", background: AT.bg,
+      }}>
+        <div style={{ padding: "14px 16px 10px" }}>
+          <div style={{ fontFamily: AT.mono, fontSize: 10, color: AT.ink3, letterSpacing: "0.14em", textTransform: "uppercase" }}>
+            Sheet 02 · Threads
+          </div>
+          <h2 style={{ margin: "4px 0 0", fontFamily: AT.serif, fontWeight: 500,
+                        fontSize: 22, letterSpacing: "-0.015em" }}>Messages</h2>
+        </div>
+        <div style={{ overflow: "auto", flex: 1, padding: "4px 6px 12px" }}>
+          {conversations.map(c => {
+            const on = c.id === activeThread.contactId;
+            return (
+              <div key={c.id} style={{
+                display: "grid", gridTemplateColumns: "30px 1fr auto",
+                padding: "9px 10px", gap: 8, alignItems: "center",
+                cursor: "pointer",
+                background: on ? AT.accentW : "transparent",
+                borderLeft: on ? `2px solid ${AT.accent}` : "2px solid transparent",
+                marginLeft: on ? 0 : 2, marginBottom: 1,
+              }}>
+                <div style={{
+                  width: 28, height: 28, borderRadius: 2,
+                  background: `oklch(86% 0.05 ${c.avatarHue})`,
+                  border: `1px solid ${AT.ruleStr}`,
+                  display: "flex", alignItems: "center", justifyContent: "center",
+                  fontSize: 12, color: AT.ink, fontWeight: 600, fontFamily: AT.serif,
+                }}>{c.name[0]}</div>
+                <div style={{ minWidth: 0 }}>
+                  <div style={{ fontSize: 13, color: AT.ink, fontWeight: on ? 600 : 500, fontFamily: AT.serif, letterSpacing: "-0.005em" }}>{c.name}</div>
+                  <div style={{ fontSize: 11.5, color: AT.ink2, fontFamily: AT.sans,
+                                 whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }}>{c.preview}</div>
+                </div>
+                <div style={{ fontFamily: AT.mono, fontSize: 9.5, color: AT.ink3 }}>{c.time}</div>
+              </div>
+            );
+          })}
+        </div>
+      </aside>
+
+      <section style={{ flex: 1, display: "flex", flexDirection: "column", minWidth: 0 }}>
+        <div style={{
+          padding: "14px 24px", borderBottom: `1px solid ${AT.ruleStr}`,
+          display: "flex", alignItems: "center", gap: 12,
+        }}>
+          <div style={{
+            width: 34, height: 34, borderRadius: 2,
+            background: "oklch(86% 0.05 14)", border: `1px solid ${AT.ruleStr}`,
+            display: "flex", alignItems: "center", justifyContent: "center",
+            fontFamily: AT.serif, fontSize: 15, fontWeight: 600,
+          }}>E</div>
+          <div style={{ flex: 1 }}>
+            <div style={{ fontFamily: AT.serif, fontSize: 17, fontWeight: 500, letterSpacing: "-0.01em" }}>Emma Whitfield</div>
+            <div style={{ fontSize: 10.5, color: AT.ink3, fontFamily: AT.mono, letterSpacing: "0.08em", textTransform: "uppercase" }}>
+              847 msgs · thread 02‑141
+            </div>
+          </div>
+          <button style={{
+            background: AT.accent, color: "#fff", border: 0,
+            padding: "7px 14px", borderRadius: 2, fontSize: 11,
+            fontFamily: AT.mono, letterSpacing: "0.08em", textTransform: "uppercase", fontWeight: 600,
+            display: "inline-flex", gap: 5, alignItems: "center",
+          }}>
+            <Icons.Export size={11} strokeWidth={1.8}/> Plot
+          </button>
+        </div>
+
+        {/* scrubber: blueprint hairline ruler */}
+        <div style={{ padding: "14px 28px 10px", borderBottom: `1px solid ${AT.ruleStr}`, background: AT.bg }}>
+          <div style={{ position: "relative", height: 28 }}>
+            {/* baseline */}
+            <div style={{ position: "absolute", left: 0, right: 0, top: 18, height: 1, background: AT.ink3 }}/>
+            {/* major ticks (years) */}
+            {[2016,2017,2018,2019,2020,2021,2022,2023].map((y, i, arr) => {
+              const x = (i / (arr.length - 1)) * 100;
+              const active = y === 2023;
+              return (
+                <Fragment key={y}>
+                  <div style={{
+                    position: "absolute", left: `${x}%`, top: 10,
+                    width: 1, height: 10, background: AT.ink3,
+                  }}/>
+                  <div style={{
+                    position: "absolute", left: `${x}%`, top: 0,
+                    transform: "translateX(-50%)",
+                    fontFamily: AT.mono, fontSize: 10, color: active ? AT.accent : AT.ink2,
+                    fontWeight: active ? 600 : 400,
+                  }}>{y}</div>
+                </Fragment>
+              );
+            })}
+            {/* minor ticks */}
+            {Array.from({ length: 85 }).map((_, i) => {
+              const x = (i / 84) * 100;
+              return (
+                <div key={i} style={{
+                  position: "absolute", left: `${x}%`, top: 14,
+                  width: 0.5, height: 5, background: AT.ink3, opacity: 0.5,
+                }}/>
+              );
+            })}
+            {/* caret */}
+            <div style={{
+              position: "absolute", left: "95%", top: 15, transform: "translateX(-50%)",
+              width: 0, height: 0,
+              borderLeft: "5px solid transparent", borderRight: "5px solid transparent",
+              borderTop: `7px solid ${AT.accent}`,
+            }}/>
+          </div>
+        </div>
+
+        <div style={{ flex: 1, overflow: "auto", padding: "22px 32px" }}>
+          <div style={{
+            textAlign: "center", fontFamily: AT.mono, fontSize: 10.5, color: AT.ink3,
+            letterSpacing: "0.14em", textTransform: "uppercase", marginBottom: 16,
+          }}>↧ 2023.08.14 — 14:02 ↧</div>
+          {activeThread.messages.map(m => {
+            const mine = m.from === "me";
+            return (
+              <div key={m.id} style={{
+                display: "flex", justifyContent: mine ? "flex-end" : "flex-start", marginBottom: 5,
+              }}>
+                <div style={{
+                  maxWidth: "62%",
+                  background: mine ? AT.bubbleMe : AT.bubbleThem,
+                  color: mine ? AT.bg : AT.ink,
+                  padding: m.kind === "photo" ? 4 : "9px 13px",
+                  borderRadius: 3,
+                  border: mine ? "none" : `1px solid ${AT.ruleStr}`,
+                  fontSize: 13.5, lineHeight: 1.5, fontFamily: AT.serif, letterSpacing: "-0.005em",
+                }}>
+                  {m.kind === "photo" ? (
+                    <div style={{
+                      width: 220, height: 160, borderRadius: 2, overflow: "hidden",
+                      background: "linear-gradient(135deg, oklch(70% 0.08 45), oklch(45% 0.1 30))",
+                      position: "relative",
+                    }}>
+                      <div style={{ position: "absolute", left: 8, bottom: 6,
+                                     fontFamily: AT.mono, fontSize: 10, color: "#fff" }}>{m.caption}</div>
+                    </div>
+                  ) : m.text}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      </section>
+    </div>
+  );
+};
+
+// --- Novel CONTACTS: blueprint node-map ---
+const AtelierContactsNovel = ({ contacts, tokens: T }) => {
+  // pick top 8 by frequency + the rest as dim peripheral nodes
+  const top = contacts.slice().sort((a, b) => b.freq - a.freq).slice(0, 8);
+  const cx = 520, cy = 320;
+  const radius = 240;
+
+  return (
+    <div style={{ flex: 1, overflow: "auto", padding: "22px 30px 30px" }}>
+      <div style={{
+        background: T.surface, border: `1px solid ${T.ruleStr}`, position: "relative",
+      }}>
+        {/* title bar */}
+        <div style={{
+          padding: "8px 14px", borderBottom: `1px solid ${T.ruleStr}`,
+          display: "flex", alignItems: "center",
+          fontFamily: T.mono, fontSize: 10, color: T.ink3, letterSpacing: "0.14em",
+          textTransform: "uppercase", background: T.sunk,
+        }}>
+          <span>DWG 06 — Contacts · connection graph</span>
+          <span style={{ flex: 1 }}/>
+          <span>edges: call frequency · node size: messages</span>
+        </div>
+        <svg viewBox="0 0 1040 680" width="100%" height="560" style={{ display: "block" }}>
+          <defs>
+            <pattern id="grid-at" width="40" height="40" patternUnits="userSpaceOnUse">
+              <path d="M 40 0 L 0 0 0 40" fill="none" stroke={T.rule} strokeWidth="0.5"/>
+            </pattern>
+          </defs>
+          <rect width="1040" height="680" fill="url(#grid-at)"/>
+
+          {/* edges from top contacts to center (MOM) */}
+          {top.map((c, i) => {
+            const angle = (i / top.length) * Math.PI * 2;
+            const r = radius * (0.55 + (1 - c.freq / top[0].freq) * 0.45);
+            const x = cx + Math.cos(angle) * r;
+            const y = cy + Math.sin(angle) * r;
+            const thickness = Math.max(0.7, c.freq / 140);
+            return (
+              <line key={`e-${i}`} x1={cx} y1={cy} x2={x} y2={y}
+                    stroke={T.accent} strokeWidth={thickness} opacity={0.7}
+                    strokeDasharray={c.freq < 100 ? "3 4" : undefined}/>
+            );
+          })}
+
+          {/* center (Mom) */}
+          <circle cx={cx} cy={cy} r={26} fill={T.accent}/>
+          <circle cx={cx} cy={cy} r={36} fill="none" stroke={T.accent} strokeDasharray="2 4" opacity={0.4}/>
+          <text x={cx} y={cy + 4} fontSize="11" fontFamily={T.mono} fontWeight={700}
+                fill="#fff" textAnchor="middle" letterSpacing="0.12em">MOM</text>
+
+          {/* top nodes */}
+          {top.map((c, i) => {
+            const angle = (i / top.length) * Math.PI * 2;
+            const r = radius * (0.55 + (1 - c.freq / top[0].freq) * 0.45);
+            const x = cx + Math.cos(angle) * r;
+            const y = cy + Math.sin(angle) * r;
+            const size = 12 + Math.min(c.freq / 50, 18);
+            const textOffsetX = Math.cos(angle) * (size + 16);
+            const textOffsetY = Math.sin(angle) * (size + 18);
+            const anchor = Math.cos(angle) > 0.2 ? "start" : Math.cos(angle) < -0.2 ? "end" : "middle";
+            return (
+              <g key={i}>
+                <circle cx={x} cy={y} r={size} fill={`oklch(88% 0.05 ${c.hue})`}
+                        stroke={T.accent} strokeWidth={1.5}/>
+                <text x={x} y={y + 4} fontSize="11" fontFamily={T.serif} fill={T.ink}
+                      textAnchor="middle" fontWeight={600}>{c.name[0]}</text>
+                <text x={x + textOffsetX} y={y + textOffsetY - 4} fontSize="11.5"
+                      fontFamily={T.serif} fill={T.ink} textAnchor={anchor}
+                      fontWeight={600}>{c.name}</text>
+                <text x={x + textOffsetX} y={y + textOffsetY + 8} fontSize="10"
+                      fontFamily={T.mono} fill={T.ink3} textAnchor={anchor}>
+                  {c.role} · {c.freq} msgs
+                </text>
+              </g>
+            );
+          })}
+
+          {/* peripheral dim nodes */}
+          {Array.from({ length: 40 }).map((_, i) => {
+            const angle = (i / 40) * Math.PI * 2 + 0.17;
+            const r = 290 + (i % 5) * 14;
+            const x = cx + Math.cos(angle) * r;
+            const y = cy + Math.sin(angle) * r;
+            return <circle key={i} cx={x} cy={y} r={2} fill={T.ink3} opacity={0.4}/>;
+          })}
+        </svg>
+
+        {/* footer strip */}
+        <div style={{
+          padding: "8px 14px", borderTop: `1px solid ${T.ruleStr}`,
+          display: "flex", alignItems: "center",
+          fontFamily: T.mono, fontSize: 10, color: T.ink3, letterSpacing: "0.1em",
+          textTransform: "uppercase", background: T.sunk,
+        }}>
+          <span>612 contacts · 8 inner circle · 40 peripheral shown</span>
+          <span style={{ flex: 1 }}/>
+          <span>CLICK A NODE FOR DETAIL</span>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+window.AtelierRoot = ({ screen }) => {
+  const overrides = {
+    backup:   <AtelierBackup/>,
+    messages: <AtelierMessages/>,
+  };
+  const custom = overrides[screen];
+  if (custom) {
+    return (
+      <AtelierChrome>
+        <div style={{ flex: 1, display: "flex", minHeight: 0 }}>
+          {screen !== "backup" && <AtelierSidebar active={screen}/>}
+          {custom}
+        </div>
+      </AtelierChrome>
+    );
+  }
+  return window.SharedScreens.render({
+    screen, tokens: AT, Sidebar: AtelierSidebar, Chrome: AtelierChrome,
+    backupComponent: AtelierBackup, messagesComponent: AtelierMessages,
+    novelContacts: (args) => <AtelierContactsNovel {...args}/>,
+  });
+};

--- a/mockups/app/app-mockups/data.jsx
+++ b/mockups/app/app-mockups/data.jsx
@@ -1,0 +1,182 @@
+// Shared sample data for all four variants.
+// Warm/personal memory-recovery tone.
+
+window.OE_DATA = {
+  backups: [
+    {
+      id: "iphone-13-pro",
+      device: "iPhone 13 Pro",
+      owner: "Mom's phone",
+      ios: "iOS 17.6.1",
+      color: "Sierra Blue",
+      lastBackup: "Aug 14, 2023",
+      relative: "2 years ago",
+      size: "84.2 GB",
+      encrypted: true,
+      photos: 12847,
+      messages: 48213,
+      contacts: 612,
+      voicemails: 24,
+      calls: 4281,
+      notes: 189,
+      years: [2019, 2020, 2021, 2022, 2023],
+      activity: [3,5,6,8,10,14,18,22,19,16,12,8, 6,7,9,11,14,18,24,26,23,19,14,10, 8,9,11,14,17,22,28,30,27,22,16,11],
+    },
+    {
+      id: "iphone-xs",
+      device: "iPhone XS",
+      owner: "Dad — old phone",
+      ios: "iOS 15.7",
+      color: "Space Gray",
+      lastBackup: "Mar 02, 2021",
+      relative: "4 years ago",
+      size: "52.1 GB",
+      encrypted: false,
+      photos: 6012,
+      messages: 22104,
+      contacts: 438,
+      voicemails: 9,
+      calls: 2140,
+      notes: 67,
+      years: [2017, 2018, 2019, 2020, 2021],
+      activity: [2,3,4,5,7,9,12,14,12,10,8,6, 5,6,8,10,13,16,19,20,17,13,9,6, 4,5,7,9,11,13,15,16,13,10,7,5],
+    },
+    {
+      id: "iphone-7",
+      device: "iPhone 7",
+      owner: "My old phone",
+      ios: "iOS 14.8",
+      color: "Rose Gold",
+      lastBackup: "Dec 22, 2019",
+      relative: "6 years ago",
+      size: "28.7 GB",
+      encrypted: true,
+      photos: 3298,
+      messages: 9847,
+      contacts: 221,
+      voicemails: 3,
+      calls: 812,
+      notes: 42,
+      years: [2016, 2017, 2018, 2019],
+      activity: [1,2,3,4,6,8,10,11,9,7,5,3, 3,4,5,7,9,11,13,14,11,8,6,4, 2,3,4,5,7,9,11,12,10,7,5,3],
+    },
+  ],
+
+  // Messages — mom's phone conversation list
+  conversations: [
+    { id: "emma",   name: "Emma",           preview: "sent a photo",                     time: "2:14 PM", unread: false, avatarHue: 14,  role: "daughter" },
+    { id: "sarah",  name: "Sarah Whitfield", preview: "ok love you — see you Sunday 💐", time: "11:42 AM", unread: false, avatarHue: 340, role: "sister" },
+    { id: "dad",    name: "Dad ❤",           preview: "the dock is finally finished",    time: "Mon",      unread: false, avatarHue: 200, role: "husband" },
+    { id: "book",   name: "Book Club",       preview: "Marjorie: chapter 12 kills me",   time: "Sun",      unread: false, avatarHue: 120, role: "group" },
+    { id: "linda",  name: "Linda Park",      preview: "happy birthday!!",                 time: "Aug 4",    unread: false, avatarHue: 45, role: "friend" },
+    { id: "ethan",  name: "Ethan",           preview: "landed. calling now",              time: "Jul 28",   unread: false, avatarHue: 260, role: "son" },
+    { id: "carol",  name: "Carol Whitfield", preview: "the tomatoes came in",             time: "Jul 15",   unread: false, avatarHue: 80,  role: "mother" },
+    { id: "vet",    name: "Elmwood Vet",     preview: "Biscuit is ready for pickup",      time: "Jun 30",   unread: false, avatarHue: 180, role: "service" },
+  ],
+
+  // Active conversation (Emma) — a warm exchange from a summer afternoon
+  activeThread: {
+    contactId: "emma",
+    name: "Emma",
+    subtitle: "Daughter · 847 messages · 2016–2023",
+    messages: [
+      { id: 1, from: "them", text: "look what I found in the attic!!", time: "2:02 PM", date: "Aug 14, 2023" },
+      { id: 2, from: "them", kind: "photo", caption: "attic find — old polaroids", time: "2:02 PM" },
+      { id: 3, from: "me",   text: "oh my god. is that grandma's sewing box??", time: "2:06 PM" },
+      { id: 4, from: "them", text: "yep. full of buttons, threads, everything", time: "2:08 PM" },
+      { id: 5, from: "them", text: "I want to keep it", time: "2:08 PM" },
+      { id: 6, from: "me",   text: "of course. she would love that ❤", time: "2:10 PM" },
+      { id: 7, from: "them", text: "also found a stack of letters. dad 1987 — so young", time: "2:12 PM" },
+      { id: 8, from: "them", kind: "photo", caption: "letters — 1987", time: "2:13 PM" },
+      { id: 9, from: "me",   text: "bring them to sunday dinner, we'll read together", time: "2:14 PM" },
+    ]
+  },
+
+  // Helpful context snippets (used in margin rails for Almanac, etc.)
+  marginalia: [
+    { anchorId: 2, label: "Aug 2023", note: "12,847 photos recovered from this backup" },
+    { anchorId: 5, label: "Emma, 17", note: "attic cleanout, Whitfield house" },
+    { anchorId: 8, label: "1987",     note: "23 letters attached — could export as PDF" },
+  ],
+
+  // --- Timeline events (newest first) ---
+  timeline: [
+    { type: "photo",    date: "Aug 14, 2023", time: "2:13 PM", title: "12 photos from the attic", meta: "Emma · iCloud Photo Library", hue: 14 },
+    { type: "message",  date: "Aug 14, 2023", time: "2:14 PM", title: "Emma", meta: "“bring them to sunday dinner”", hue: 14 },
+    { type: "call",     date: "Aug 13, 2023", time: "6:42 PM", title: "Dad ❤", meta: "Outgoing · 14m 22s", hue: 200 },
+    { type: "voicemail",date: "Aug 11, 2023", time: "9:18 AM", title: "Dr. Okafor — Elmwood Vet", meta: "0:48 · Biscuit is ready", hue: 180 },
+    { type: "note",     date: "Aug 09, 2023", time: "7:02 AM", title: "Grocery list", meta: "bread, peaches, vanilla…", hue: 80 },
+    { type: "photo",    date: "Aug 04, 2023", time: "5:30 PM", title: "Linda's birthday dinner — 38 photos", meta: "Garden, Whitfield house", hue: 45 },
+    { type: "message",  date: "Jul 28, 2023", time: "11:02 PM", title: "Ethan", meta: "“landed. calling now”", hue: 260 },
+    { type: "call",     date: "Jul 28, 2023", time: "11:03 PM", title: "Ethan", meta: "Incoming · 8m 09s", hue: 260 },
+    { type: "photo",    date: "Jul 15, 2023", time: "10:14 AM", title: "First tomatoes", meta: "Garden · 4 photos", hue: 80 },
+    { type: "message",  date: "Jun 30, 2023", time: "3:48 PM", title: "Elmwood Vet", meta: "“Biscuit is ready for pickup”", hue: 180 },
+  ],
+
+  // --- Photos (gallery sample) ---
+  photos: [
+    { id: "p01", album: "Attic find",          date: "Aug 14", count: 12,  hue: 32,  big: true  },
+    { id: "p02", album: "Linda's birthday",    date: "Aug 04", count: 38,  hue: 45,  big: false },
+    { id: "p03", album: "Garden, July",        date: "Jul 15", count: 24,  hue: 80,  big: false },
+    { id: "p04", album: "Ethan home",          date: "Jul 28", count: 17,  hue: 260, big: true  },
+    { id: "p05", album: "Dock is finished",    date: "Jul 03", count: 9,   hue: 200, big: false },
+    { id: "p06", album: "Farmers market",      date: "Jun 18", count: 31,  hue: 14,  big: false },
+    { id: "p07", album: "Biscuit",             date: "Jun 11", count: 22,  hue: 180, big: false },
+    { id: "p08", album: "Book club, Sunday",   date: "May 21", count: 8,   hue: 120, big: false },
+    { id: "p09", album: "Coast trip",          date: "Apr 30", count: 64,  hue: 210, big: true  },
+    { id: "p10", album: "Roses",               date: "Apr 12", count: 11,  hue: 340, big: false },
+    { id: "p11", album: "Grandkids",           date: "Mar 26", count: 53,  hue: 35,  big: false },
+    { id: "p12", album: "Spring cleaning",     date: "Mar 08", count: 19,  hue: 90,  big: false },
+  ],
+
+  // --- Voicemails ---
+  voicemails: [
+    { id: "v1", from: "Dr. Okafor — Elmwood Vet", date: "Aug 11, 2023", time: "9:18 AM", duration: "0:48", transcript: "Hi Mrs. Whitfield — Biscuit is all set, ready for pickup any time after noon. He did great.", unread: false },
+    { id: "v2", from: "Sarah Whitfield",          date: "Jul 22, 2023", time: "4:02 PM", duration: "1:24", transcript: "Hey it's me — just calling to say the casserole dish is at Mom's if you're looking for it. Love you.", unread: false },
+    { id: "v3", from: "Unknown",                  date: "Jul 10, 2023", time: "11:55 AM", duration: "0:12", transcript: "[silence]", unread: false },
+    { id: "v4", from: "Dad ❤",                    date: "Jun 24, 2023", time: "8:41 PM", duration: "2:03", transcript: "Hi honey — the dock is finally done. Came out beautiful. Come see it this weekend if you can.", unread: false },
+    { id: "v5", from: "Linda Park",               date: "Jun 02, 2023", time: "5:28 PM", duration: "0:52", transcript: "Hi Marie! Just confirming dinner on the 4th — 7 PM, bring that peach thing you make.", unread: false },
+    { id: "v6", from: "Ethan",                    date: "May 19, 2023", time: "1:17 PM", duration: "0:34", transcript: "Mom, ignore what I said about the flight — moved it to Friday. Talk soon.", unread: false },
+  ],
+
+  // --- Calls (recent) ---
+  calls: [
+    { dir: "out",     who: "Dad ❤",              date: "Aug 13 · 6:42 PM", dur: "14m 22s", svc: "FaceTime" },
+    { dir: "in",      who: "Emma",               date: "Aug 13 · 2:06 PM", dur: "3m 01s",  svc: "Phone"    },
+    { dir: "missed",  who: "Unknown (local)",    date: "Aug 12 · 9:04 AM", dur: "—",       svc: "Phone"    },
+    { dir: "in",      who: "Sarah Whitfield",    date: "Aug 11 · 11:42 AM",dur: "22m 44s", svc: "Phone"    },
+    { dir: "out",     who: "Elmwood Vet",        date: "Aug 11 · 8:58 AM", dur: "1m 12s",  svc: "Phone"    },
+    { dir: "in",      who: "Linda Park",         date: "Aug 04 · 7:14 PM", dur: "5m 30s",  svc: "Phone"    },
+    { dir: "out",     who: "Ethan",              date: "Jul 28 · 11:03 PM",dur: "8m 09s",  svc: "FaceTime" },
+    { dir: "missed",  who: "Spam Likely",        date: "Jul 27 · 3:01 PM", dur: "—",       svc: "Phone"    },
+    { dir: "out",     who: "Carol Whitfield",    date: "Jul 15 · 9:28 AM", dur: "47m 12s", svc: "Phone"    },
+    { dir: "in",      who: "Book Club",          date: "Jul 09 · 4:00 PM", dur: "1h 12m",  svc: "Phone"    },
+  ],
+
+  // --- Contacts (richer) ---
+  contacts: [
+    { name: "Emma Whitfield",    role: "Daughter",   phone: "555-0141", email: "emma@whitfield.fam",  hue: 14,  freq: 847 },
+    { name: "Dad ❤",             role: "Husband",    phone: "555-0102", email: "j.whitfield@me.com",  hue: 200, freq: 612 },
+    { name: "Ethan Whitfield",   role: "Son",        phone: "555-0187", email: "ethan@whitfield.fam", hue: 260, freq: 428 },
+    { name: "Sarah Whitfield",   role: "Sister",     phone: "555-0199", email: "sarah.w@gmail.com",   hue: 340, freq: 401 },
+    { name: "Linda Park",        role: "Best friend",phone: "555-0123", email: "lindap@me.com",       hue: 45,  freq: 312 },
+    { name: "Carol Whitfield",   role: "Mother",     phone: "555-0166", email: null,                   hue: 80,  freq: 289 },
+    { name: "Dr. R. Okafor",     role: "Vet",        phone: "555-0190", email: "care@elmwoodvet.com", hue: 180, freq: 42  },
+    { name: "Book Club",         role: "Group",      phone: "—",        email: null,                   hue: 120, freq: 88  },
+    { name: "Marjorie Finch",    role: "Book club",  phone: "555-0117", email: "marj@gmail.com",      hue: 300, freq: 64  },
+    { name: "Pastor Lee",        role: "Community",  phone: "555-0143", email: null,                   hue: 220, freq: 31  },
+    { name: "Paul the plumber",  role: "Service",    phone: "555-0175", email: null,                   hue: 30,  freq: 9   },
+    { name: "Pharmacy",          role: "Service",    phone: "555-0188", email: null,                   hue: 150, freq: 22  },
+  ],
+
+  // --- Notes ---
+  notes: [
+    { id: "n1", title: "Grandkids' sizes",          date: "Aug 10, 2023", preview: "Emma: medium, navy preferred. Nora: 6X, avoid pink if possible. Ethan: large…", pinned: true  },
+    { id: "n2", title: "Grocery list",              date: "Aug 09, 2023", preview: "bread, peaches, vanilla, olive oil, that cheese Dad likes", pinned: false },
+    { id: "n3", title: "Mom's peach cobbler",       date: "Jul 30, 2023", preview: "6 peaches, 1c flour, 1c sugar, 1 stick butter, 1c milk, tsp baking powder…", pinned: true  },
+    { id: "n4", title: "Books to read next",        date: "Jul 14, 2023", preview: "Demon Copperhead (Marjorie rec), Tom Lake, Trust (Hernan Diaz)", pinned: false },
+    { id: "n5", title: "Passwords (old router)",    date: "Mar 02, 2023", preview: "not storing any here anymore — use the little book", pinned: false },
+    { id: "n6", title: "Letters in attic (1987)",   date: "Aug 14, 2023", preview: "23 letters, Dad to Mom. Postmarks: Ann Arbor, Boulder, Charleston.", pinned: false },
+    { id: "n7", title: "Biscuit vet notes",         date: "Jun 11, 2023", preview: "senior food, half scoop breakfast, no table scraps per Dr. Okafor", pinned: false },
+  ],
+};

--- a/mockups/app/app-mockups/garden.jsx
+++ b/mockups/app/app-mockups/garden.jsx
@@ -1,0 +1,463 @@
+// ======================================================================
+// GARDEN — Soft pastels, organic. Cream background, sage primary.
+// Novel UX: Photos as a "year-radius bloom" — concentric year rings with
+// photo clusters blooming outward.
+// ======================================================================
+
+const GD = {
+  bg:       "#faf6ee",
+  surface:  "#fffcf5",
+  sunk:     "#f2ecdf",
+  ink:      "#1f241a",
+  ink2:     "#5a5f50",
+  ink3:     "#8f9284",
+  rule:     "#e7dfce",
+  ruleStr:  "#d3c9b2",
+  accent:   "#6b8c5a",   // sage
+  accentW:  "#e5ead9",
+  sans:     "'Inter', system-ui, sans-serif",
+  serif:    "'Fraunces', 'Newsreader', serif",
+  mono:     "'JetBrains Mono', monospace",
+  titleSerif: true,
+  titleWeight: 400,
+  titleLetter: "-0.02em",
+  radius:   14,
+  bubbleMe:  "#6b8c5a",
+  bubbleThem:"#fffcf5",
+  chipActive: "#6b8c5a",
+  chipActiveFg: "#fffcf5",
+  chipFg: "#5a5f50",
+};
+
+const GardenChrome = ({ children }) => (
+  <div style={{
+    background: GD.bg, color: GD.ink, height: "100%",
+    fontFamily: GD.sans, display: "flex", flexDirection: "column",
+  }}>
+    <div style={{
+      height: 46, display: "flex", alignItems: "center", padding: "0 18px",
+      background: GD.bg, borderBottom: `1px solid ${GD.rule}`, flexShrink: 0,
+    }}>
+      <div className="tl"><span className="r"/><span className="y"/><span className="g"/></div>
+      <div style={{ marginLeft: 18, fontSize: 14, fontFamily: GD.serif, fontWeight: 500, letterSpacing: "-0.01em" }}>
+        OpenExtract
+      </div>
+      <span style={{ width: 4, height: 4, borderRadius: 99, background: GD.accent, margin: "0 12px" }}/>
+      <span style={{ fontSize: 12, color: GD.ink2, fontFamily: GD.serif, fontStyle: "italic" }}>
+        Mom's iPhone, summer of '23
+      </span>
+      <div style={{ flex: 1 }}/>
+      <span style={{ fontSize: 11, color: GD.ink3, fontFamily: GD.mono, letterSpacing: "0.06em" }}>LOCAL</span>
+    </div>
+    {children}
+  </div>
+);
+
+const GardenSidebar = ({ active }) => {
+  const Icons = window.OEIcons;
+  const items = [
+    { id: "timeline",  label: "Timeline",  I: Icons.Clock },
+    { id: "messages",  label: "Messages",  I: Icons.Message },
+    { id: "photos",    label: "Photos",    I: Icons.Image },
+    { id: "voicemail", label: "Voicemail", I: Icons.Voicemail },
+    { id: "calls",     label: "Calls",     I: Icons.Phone },
+    { id: "contacts",  label: "Contacts",  I: Icons.User },
+    { id: "notes",     label: "Notes",     I: Icons.FileText },
+  ];
+  return (
+    <nav style={{
+      width: 216, flexShrink: 0, padding: "18px 12px",
+      borderRight: `1px solid ${GD.rule}`, background: GD.bg,
+      display: "flex", flexDirection: "column",
+    }}>
+      <div style={{ fontSize: 10.5, color: GD.ink3, letterSpacing: "0.12em",
+                    textTransform: "uppercase", padding: "4px 10px 10px", fontWeight: 600 }}>The garden</div>
+      {items.map(it => {
+        const on = it.id === active;
+        const I = it.I;
+        return (
+          <div key={it.id} style={{
+            display: "flex", alignItems: "center", gap: 10,
+            padding: "8px 12px", borderRadius: 99, cursor: "pointer",
+            color: on ? GD.ink : GD.ink2,
+            background: on ? GD.accentW : "transparent",
+            marginBottom: 2,
+          }}>
+            <I size={15} strokeWidth={1.5} stroke={on ? GD.accent : GD.ink2}/>
+            <span style={{ fontSize: 13, fontWeight: on ? 500 : 400, letterSpacing: "-0.005em" }}>{it.label}</span>
+          </div>
+        );
+      })}
+      <div style={{ flex: 1 }}/>
+      <div style={{
+        padding: "14px 12px 6px", fontSize: 11.5, color: GD.ink2,
+        borderTop: `1px solid ${GD.rule}`, marginTop: 14, fontFamily: GD.serif, fontStyle: "italic",
+        lineHeight: 1.5,
+      }}>
+        "Like pressing flowers — but for a whole life."
+      </div>
+    </nav>
+  );
+};
+
+// --- Backup: pastel "seed packet" cards ---
+const GardenBackup = () => {
+  const backups = window.OE_DATA.backups;
+  const Icons = window.OEIcons;
+  const hues = [110, 40, 340];
+
+  return (
+    <div style={{ flex: 1, overflow: "auto", background: GD.bg }}>
+      <div style={{ padding: "54px 56px 20px" }}>
+        <div style={{
+          fontSize: 10.5, color: GD.ink3, letterSpacing: "0.14em",
+          textTransform: "uppercase", fontWeight: 600,
+        }}>Choose a backup to begin</div>
+        <h1 style={{
+          margin: "12px 0 8px", fontFamily: GD.serif, fontWeight: 400,
+          fontSize: 52, letterSpacing: "-0.025em", lineHeight: 1.02,
+        }}>
+          <span style={{ fontStyle: "italic" }}>Three</span> gardens, grown on three phones.
+        </h1>
+        <p style={{ maxWidth: 580, fontSize: 14.5, lineHeight: 1.65, color: GD.ink2, margin: "8px 0 0" }}>
+          Each backup is a season of life — pick one to wander through. No uploads, no accounts, no hurry.
+        </p>
+      </div>
+
+      <div style={{ padding: "28px 56px 56px", display: "grid",
+                    gridTemplateColumns: "repeat(3, 1fr)", gap: 22 }}>
+        {backups.map((b, i) => (
+          <div key={b.id} style={{
+            background: GD.surface, border: `1px solid ${GD.rule}`, borderRadius: 22,
+            padding: "26px 24px 22px", position: "relative", overflow: "hidden",
+          }}>
+            {/* decorative "seed" badge */}
+            <div style={{
+              position: "absolute", top: -40, right: -40, width: 160, height: 160,
+              borderRadius: "50%",
+              background: `radial-gradient(circle, oklch(88% 0.08 ${hues[i]}) 0%, transparent 70%)`,
+              opacity: 0.85,
+            }}/>
+            <div style={{
+              fontFamily: GD.serif, fontStyle: "italic", fontSize: 12.5, color: GD.ink3,
+            }}>№ {i + 1} — {b.relative}</div>
+            <h3 style={{
+              margin: "8px 0 2px", fontFamily: GD.serif, fontWeight: 500,
+              fontSize: 28, letterSpacing: "-0.02em",
+            }}>{b.device}</h3>
+            <div style={{ fontSize: 13, color: GD.ink2, marginBottom: 18 }}>{b.owner}</div>
+
+            {/* stats in a soft grid */}
+            <div style={{
+              display: "grid", gridTemplateColumns: "1fr 1fr", gap: "8px 16px",
+              padding: "14px 0", borderTop: `1px solid ${GD.rule}`, borderBottom: `1px solid ${GD.rule}`,
+              marginBottom: 16,
+            }}>
+              {[
+                ["Photos",     b.photos.toLocaleString()],
+                ["Messages",   b.messages.toLocaleString()],
+                ["Calls",      b.calls.toLocaleString()],
+                ["Voicemails", b.voicemails],
+                ["Period",     `${b.years[0]}–${b.years[b.years.length-1]}`],
+                ["Size",       b.size],
+              ].map(([k, v]) => (
+                <div key={k}>
+                  <div style={{ fontSize: 10, color: GD.ink3, letterSpacing: "0.08em",
+                                textTransform: "uppercase", fontWeight: 600 }}>{k}</div>
+                  <div style={{ fontSize: 13.5, color: GD.ink, fontFamily: GD.mono, marginTop: 2 }}>{v}</div>
+                </div>
+              ))}
+            </div>
+
+            <button style={{
+              width: "100%", padding: "10px 14px",
+              background: i === 0 ? GD.accent : "transparent",
+              color: i === 0 ? "#fff" : GD.ink,
+              border: `1px solid ${i === 0 ? GD.accent : GD.ruleStr}`,
+              borderRadius: 99, fontSize: 13, fontWeight: 500,
+              display: "inline-flex", alignItems: "center", justifyContent: "center", gap: 6,
+              fontFamily: GD.sans,
+            }}>
+              {i === 0 ? "Open this backup" : "Open"} <Icons.ArrowRight size={12} strokeWidth={2}/>
+            </button>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+// --- Messages with pastel wave scrubber ---
+const GardenMessages = () => {
+  const { conversations, activeThread } = window.OE_DATA;
+  const Icons = window.OEIcons;
+
+  return (
+    <div style={{ flex: 1, display: "flex", background: GD.bg, minWidth: 0 }}>
+      <aside style={{
+        width: 288, flexShrink: 0, borderRight: `1px solid ${GD.rule}`,
+        display: "flex", flexDirection: "column",
+      }}>
+        <div style={{ padding: "18px 18px 10px" }}>
+          <h2 style={{ margin: 0, fontFamily: GD.serif, fontWeight: 500,
+                       fontSize: 22, letterSpacing: "-0.01em" }}>Messages</h2>
+          <div style={{ fontSize: 11.5, color: GD.ink3, marginTop: 2, fontFamily: GD.serif, fontStyle: "italic" }}>
+            214 threads, pressed between pages
+          </div>
+          <div style={{
+            display: "flex", alignItems: "center", gap: 8, marginTop: 10,
+            background: GD.surface, border: `1px solid ${GD.rule}`, borderRadius: 99,
+            padding: "7px 12px",
+          }}>
+            <Icons.Search size={12} strokeWidth={1.5} stroke={GD.ink3}/>
+            <span style={{ fontSize: 12, color: GD.ink3 }}>Search threads</span>
+          </div>
+        </div>
+        <div style={{ overflow: "auto", flex: 1, padding: "6px 8px 16px" }}>
+          {conversations.map(c => {
+            const on = c.id === activeThread.contactId;
+            return (
+              <div key={c.id} style={{
+                display: "flex", gap: 10, padding: "9px 10px",
+                borderRadius: 14, cursor: "pointer",
+                background: on ? GD.accentW : "transparent",
+                marginBottom: 2,
+              }}>
+                <div style={{
+                  width: 34, height: 34, borderRadius: "50%", flexShrink: 0,
+                  background: `oklch(86% 0.06 ${c.avatarHue})`,
+                  border: `1px solid ${GD.rule}`,
+                  display: "flex", alignItems: "center", justifyContent: "center",
+                  fontSize: 13, color: GD.ink, fontWeight: 500, fontFamily: GD.serif,
+                }}>{c.name[0]}</div>
+                <div style={{ flex: 1, minWidth: 0 }}>
+                  <div style={{ display: "flex", justifyContent: "space-between", alignItems: "baseline" }}>
+                    <span style={{ fontSize: 13, color: GD.ink, fontWeight: on ? 600 : 500 }}>{c.name}</span>
+                    <span style={{ fontSize: 10, color: GD.ink3, fontFamily: GD.mono }}>{c.time}</span>
+                  </div>
+                  <div style={{
+                    fontSize: 12, color: GD.ink2, marginTop: 2,
+                    whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis",
+                  }}>{c.preview}</div>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      </aside>
+
+      <section style={{ flex: 1, display: "flex", flexDirection: "column", minWidth: 0 }}>
+        <div style={{
+          padding: "14px 26px", borderBottom: `1px solid ${GD.rule}`,
+          display: "flex", alignItems: "center", gap: 12,
+        }}>
+          <div style={{
+            width: 38, height: 38, borderRadius: "50%",
+            background: "oklch(86% 0.06 14)", border: `1px solid ${GD.rule}`,
+            display: "flex", alignItems: "center", justifyContent: "center",
+            fontFamily: GD.serif, fontSize: 15, fontWeight: 500,
+          }}>E</div>
+          <div style={{ flex: 1 }}>
+            <div style={{ fontFamily: GD.serif, fontSize: 17, fontWeight: 500, letterSpacing: "-0.01em" }}>Emma</div>
+            <div style={{ fontSize: 11.5, color: GD.ink3, fontStyle: "italic", fontFamily: GD.serif }}>
+              daughter · 847 messages over seven years
+            </div>
+          </div>
+          <button style={{
+            background: GD.accent, color: "#fff", border: 0,
+            padding: "7px 14px", borderRadius: 99, fontSize: 12, fontWeight: 500,
+            display: "inline-flex", gap: 5, alignItems: "center",
+          }}>
+            <Icons.Export size={12} strokeWidth={1.8}/> Export thread
+          </button>
+        </div>
+
+        {/* scrubber: pastel wave */}
+        <div style={{ padding: "12px 28px 10px", borderBottom: `1px solid ${GD.rule}`, background: GD.bg }}>
+          <svg viewBox="0 0 600 42" width="100%" height={42} style={{ display: "block", overflow: "visible" }}>
+            <defs>
+              <linearGradient id="gd-wave" x1="0" x2="1" y1="0" y2="0">
+                <stop offset="0"   stopColor="oklch(82% 0.07 340)"/>
+                <stop offset=".33" stopColor="oklch(82% 0.07 60)"/>
+                <stop offset=".66" stopColor="oklch(82% 0.07 180)"/>
+                <stop offset="1"   stopColor="oklch(60% 0.11 140)"/>
+              </linearGradient>
+            </defs>
+            {/* wave shape for each year */}
+            {[2016,2017,2018,2019,2020,2021,2022,2023].map((y, i, arr) => {
+              const x = (i / (arr.length - 1)) * 560 + 20;
+              const amp = 8 + Math.abs(Math.sin(i * 0.8)) * 10 + (y === 2023 ? 8 : 0);
+              return (
+                <g key={y}>
+                  <ellipse cx={x} cy={26} rx={26} ry={amp}
+                           fill="url(#gd-wave)" opacity={y === 2023 ? 0.95 : 0.6}/>
+                  <text x={x} y={8} fontSize="9.5" fontFamily={GD.mono}
+                        fill={y === 2023 ? GD.accent : GD.ink3} textAnchor="middle"
+                        fontWeight={y === 2023 ? 600 : 400}>{y}</text>
+                </g>
+              );
+            })}
+            <circle cx={580} cy={26} r={5} fill={GD.accent} stroke="#fff" strokeWidth={2}/>
+          </svg>
+          <div style={{ display: "flex", justifyContent: "space-between",
+                         fontSize: 11, color: GD.ink3, marginTop: 2, fontFamily: GD.serif, fontStyle: "italic" }}>
+            <span>beginning</span><span>Aug 2023 · now</span>
+          </div>
+        </div>
+
+        <div style={{ flex: 1, overflow: "auto", padding: "24px 36px" }}>
+          <div style={{
+            textAlign: "center", fontSize: 11.5, color: GD.ink3, fontFamily: GD.serif,
+            fontStyle: "italic", marginBottom: 14,
+          }}>Monday · August 14, 2023</div>
+          {activeThread.messages.map(m => {
+            const mine = m.from === "me";
+            return (
+              <div key={m.id} style={{
+                display: "flex", justifyContent: mine ? "flex-end" : "flex-start", marginBottom: 7,
+              }}>
+                <div style={{
+                  maxWidth: "62%",
+                  background: mine ? GD.bubbleMe : GD.bubbleThem,
+                  color: mine ? "#fff" : GD.ink,
+                  padding: m.kind === "photo" ? 4 : "10px 15px",
+                  borderRadius: 18,
+                  border: mine ? "none" : `1px solid ${GD.rule}`,
+                  fontSize: 14, lineHeight: 1.45,
+                }}>
+                  {m.kind === "photo" ? (
+                    <div style={{
+                      width: 230, height: 170, borderRadius: 14, overflow: "hidden",
+                      background: `
+                        linear-gradient(135deg, oklch(80% 0.08 80) 0%, oklch(65% 0.12 45) 100%)
+                      `, position: "relative",
+                    }}>
+                      <div style={{
+                        position: "absolute", left: 10, bottom: 8, right: 10,
+                        fontSize: 10.5, color: "#fff", fontFamily: GD.serif, fontStyle: "italic",
+                      }}>{m.caption}</div>
+                    </div>
+                  ) : m.text}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      </section>
+    </div>
+  );
+};
+
+// --- Novel PHOTOS view: concentric year rings, photos bloom outward ---
+const GardenPhotosBloom = () => {
+  const Icons = window.OEIcons;
+  const photos = window.OE_DATA.photos;
+  const years = [2017, 2018, 2019, 2020, 2021, 2022, 2023];
+
+  // Assign each photo to a year ring (by date approx) and a radial angle
+  const byYear = {
+    2023: photos.slice(0, 3),
+    2022: photos.slice(3, 5),
+    2021: photos.slice(5, 7),
+    2020: photos.slice(7, 9),
+    2019: photos.slice(9, 11),
+    2018: [photos[11]],
+    2017: [photos[0]], // just for visual bloom
+  };
+
+  const cx = 480, cy = 360;
+  const ringRadii = { 2023: 70, 2022: 130, 2021: 190, 2020: 250, 2019: 310, 2018: 360, 2017: 400 };
+
+  return (
+    <div style={{ flex: 1, display: "flex", flexDirection: "column", background: GD.bg, minWidth: 0 }}>
+      <div style={{
+        padding: "20px 28px 14px", borderBottom: `1px solid ${GD.rule}`,
+        display: "flex", alignItems: "flex-end", gap: 16, flexShrink: 0,
+      }}>
+        <div style={{ flex: 1 }}>
+          <div style={{ fontSize: 10.5, color: GD.ink3, letterSpacing: "0.12em", textTransform: "uppercase", fontWeight: 600 }}>
+            Photos · 12,847 · bloom view
+          </div>
+          <h1 style={{ margin: "6px 0 0", fontFamily: GD.serif, fontWeight: 400, fontSize: 32, letterSpacing: "-0.02em" }}>
+            Seven years, in rings.
+          </h1>
+        </div>
+        <div style={{ display: "flex", gap: 6 }}>
+          <button style={{ fontSize: 12, padding: "6px 12px", borderRadius: 99,
+                           background: GD.accent, color: "#fff", border: 0 }}>Bloom</button>
+          <button style={{ fontSize: 12, padding: "6px 12px", borderRadius: 99,
+                           background: "transparent", color: GD.ink2, border: `1px solid ${GD.ruleStr}` }}>Grid</button>
+        </div>
+      </div>
+
+      <div style={{ flex: 1, overflow: "auto", padding: "10px 28px 28px",
+                     display: "flex", justifyContent: "center", alignItems: "flex-start" }}>
+        <svg viewBox="0 0 960 720" width="100%" height="640" style={{ maxWidth: 960 }}>
+          {/* rings */}
+          {years.map(y => (
+            <circle key={y} cx={cx} cy={cy} r={ringRadii[y]}
+                    fill="none" stroke={GD.ruleStr} strokeDasharray="1 5" strokeWidth={1}/>
+          ))}
+          {/* year labels on rings */}
+          {years.map(y => (
+            <text key={y} x={cx} y={cy - ringRadii[y] - 6} fontSize="11"
+                  fontFamily={GD.mono} fill={y === 2023 ? GD.accent : GD.ink3}
+                  textAnchor="middle" fontWeight={y === 2023 ? 600 : 400}>{y}</text>
+          ))}
+          {/* center bud */}
+          <circle cx={cx} cy={cy} r={22} fill={GD.accent}/>
+          <text x={cx} y={cy + 4} fontSize="10" fontFamily={GD.sans} fill="#fff"
+                textAnchor="middle" fontWeight={600}>NOW</text>
+
+          {/* photo blooms */}
+          {years.map((y) => {
+            const ring = byYear[y] ?? [];
+            const r = ringRadii[y];
+            return ring.map((p, i) => {
+              const angle = (i / Math.max(ring.length, 1)) * Math.PI * 1.6 - Math.PI * 0.3 + (y * 0.3);
+              const x = cx + Math.cos(angle) * r;
+              const py = cy + Math.sin(angle) * r;
+              const size = 28 + Math.min(p.count / 3, 28);
+              return (
+                <g key={`${y}-${i}`}>
+                  <circle cx={x} cy={py} r={size} fill={`oklch(78% 0.09 ${p.hue})`} opacity={0.95}/>
+                  <circle cx={x} cy={py} r={size - 2} fill={`oklch(78% 0.09 ${p.hue})`}
+                          stroke="#fff" strokeWidth={2}/>
+                  <text x={x} y={py + 3} fontSize="10" fontFamily={GD.sans} fill={GD.ink}
+                        textAnchor="middle" fontWeight={500}>{p.count}</text>
+                  <text x={x} y={py + size + 14} fontSize="10" fontFamily={GD.serif}
+                        fontStyle="italic" fill={GD.ink2} textAnchor="middle">
+                    {p.album.length > 16 ? p.album.slice(0, 16) + "…" : p.album}
+                  </text>
+                </g>
+              );
+            });
+          })}
+        </svg>
+      </div>
+    </div>
+  );
+};
+
+window.GardenRoot = ({ screen }) => {
+  const overrides = {
+    backup:   <GardenBackup/>,
+    messages: <GardenMessages/>,
+    photos:   <GardenPhotosBloom/>,
+  };
+  const custom = overrides[screen];
+  if (custom) {
+    return (
+      <GardenChrome>
+        <div style={{ flex: 1, display: "flex", minHeight: 0 }}>
+          {screen !== "backup" && <GardenSidebar active={screen}/>}
+          {custom}
+        </div>
+      </GardenChrome>
+    );
+  }
+  return window.SharedScreens.render({
+    screen, tokens: GD, Sidebar: GardenSidebar, Chrome: GardenChrome,
+    backupComponent: GardenBackup, messagesComponent: GardenMessages,
+  });
+};

--- a/mockups/app/app-mockups/hearth.jsx
+++ b/mockups/app/app-mockups/hearth.jsx
@@ -1,0 +1,532 @@
+// ======================================================================
+// HEARTH — Photo album / dusk palette
+// Warm off-white #fbf6f1, soft terracotta & sage, organic round cards.
+// Fraunces display, Geist body.
+// Novel UX: backup picker as STACKED PHOTO CARDS you flip through;
+// messages show people as portrait circles with a subtle recent-glow.
+// ======================================================================
+
+const H = {
+  bg:      "#fbf6f1",
+  surface: "#ffffff",
+  sand:    "#f2e9dd",
+  ink:     "#1e1a16",
+  ink2:    "#655a4f",
+  ink3:    "#97897a",
+  rule:    "#ece1d1",
+  accent:  "#d97757",  // terracotta
+  sage:    "#7a9a7a",
+  cream:   "#f0d894",
+  bubbleMe: "#d97757",
+  bubbleThem: "#f2e9dd",
+};
+
+const HF = {
+  serif: "'Fraunces', 'Newsreader', serif",
+  sans:  "'Geist', system-ui, sans-serif",
+  mono:  "'IBM Plex Mono', monospace",
+};
+
+const Hearth_Chrome = ({ children }) => (
+  <div style={{
+    background: H.bg, color: H.ink, height: "100%",
+    fontFamily: HF.sans, display: "flex", flexDirection: "column",
+  }}>
+    <div style={{
+      height: 44, display: "flex", alignItems: "center", padding: "0 16px",
+      background: H.bg, borderBottom: `1px solid ${H.rule}`, flexShrink: 0,
+    }}>
+      <div className="tl"><span className="r"/><span className="y"/><span className="g"/></div>
+      <div style={{
+        marginLeft: 16, display: "flex", alignItems: "center", gap: 8,
+      }}>
+        <div style={{
+          width: 18, height: 18, borderRadius: "50%",
+          background: `radial-gradient(circle at 35% 35%, ${H.cream}, ${H.accent} 80%)`,
+        }}/>
+        <span style={{ fontFamily: HF.serif, fontSize: 16, fontWeight: 500, letterSpacing: "-0.01em" }}>
+          OpenExtract
+        </span>
+      </div>
+      <div style={{ flex: 1 }}/>
+      <div style={{
+        display: "inline-flex", alignItems: "center", gap: 8,
+        background: H.sand, border: `1px solid ${H.rule}`, borderRadius: 999,
+        padding: "4px 11px", fontSize: 11.5, color: H.ink2,
+      }}>
+        <span style={{ width: 7, height: 7, borderRadius: 999, background: H.sage }}/>
+        iPhone 13 Pro · Mom's phone
+      </div>
+    </div>
+    {children}
+  </div>
+);
+
+const Hearth_Sidebar = ({ active }) => {
+  const Icons = window.OEIcons;
+  const items = [
+    { id: "timeline",  label: "Timeline",  I: Icons.Clock },
+    { id: "messages",  label: "Messages",  I: Icons.Message },
+    { id: "photos",    label: "Photos",    I: Icons.Image },
+    { id: "voicemail", label: "Voicemail", I: Icons.Voicemail },
+    { id: "calls",     label: "Calls",     I: Icons.Phone },
+    { id: "contacts",  label: "Contacts",  I: Icons.User },
+    { id: "notes",     label: "Notes",     I: Icons.FileText },
+  ];
+  return (
+    <nav style={{
+      width: 72, flexShrink: 0, padding: "14px 8px",
+      background: H.bg, borderRight: `1px solid ${H.rule}`,
+      display: "flex", flexDirection: "column", alignItems: "center", gap: 4,
+    }}>
+      {items.map(it => {
+        const on = it.id === active;
+        const I = it.I;
+        return (
+          <div key={it.id} title={it.label} style={{
+            width: 56, height: 56, borderRadius: 14,
+            display: "flex", flexDirection: "column", alignItems: "center", justifyContent: "center",
+            gap: 3, cursor: "pointer",
+            background: on ? H.surface : "transparent",
+            boxShadow: on ? "0 1px 2px rgba(30,26,22,.06), 0 4px 14px rgba(217,119,87,.10)" : "none",
+            border: on ? `1px solid ${H.rule}` : "1px solid transparent",
+            color: on ? H.accent : H.ink2,
+          }}>
+            <I size={18} strokeWidth={1.6} stroke={on ? H.accent : H.ink2}/>
+            <span style={{ fontSize: 9.5, fontWeight: on ? 500 : 400 }}>{it.label}</span>
+          </div>
+        );
+      })}
+      <div style={{ flex: 1 }}/>
+      <div style={{
+        width: 36, height: 36, borderRadius: "50%",
+        background: `oklch(82% 0.07 14)`, border: `1px solid ${H.rule}`,
+        display: "flex", alignItems: "center", justifyContent: "center",
+        fontFamily: HF.serif, fontSize: 15,
+      }}>M</div>
+    </nav>
+  );
+};
+
+// --- BACKUP: stacked photo cards ---
+const Hearth_Backup = () => {
+  const backups = window.OE_DATA.backups;
+  const Icons = window.OEIcons;
+  const [sel, setSel] = React.useState(0);
+
+  return (
+    <div style={{ flex: 1, display: "flex", overflow: "hidden" }}>
+      {/* Left: intro copy */}
+      <div style={{
+        width: 420, padding: "60px 44px 44px",
+        display: "flex", flexDirection: "column",
+      }}>
+        <div style={{ fontFamily: HF.mono, fontSize: 10, letterSpacing: "0.16em", color: H.ink3, textTransform: "uppercase" }}>
+          Welcome back
+        </div>
+        <h1 style={{
+          fontFamily: HF.serif, fontWeight: 400, fontSize: 54, lineHeight: 1.03,
+          letterSpacing: "-0.025em", margin: "12px 0 10px",
+        }}>
+          Which phone<br/>
+          are we <span style={{ fontStyle: "italic", color: H.accent }}>opening</span>?
+        </h1>
+        <p style={{ fontSize: 14.5, lineHeight: 1.55, color: H.ink2, margin: 0, maxWidth: 340 }}>
+          Three backups live on this Mac. Flip through them, pick the one you want, and we'll gently pull out the messages, photos, and voicemails.
+        </p>
+
+        <div style={{ marginTop: 28, display: "flex", flexDirection: "column", gap: 10 }}>
+          {backups.map((b, i) => {
+            const on = i === sel;
+            return (
+              <button key={b.id} onClick={() => setSel(i)} style={{
+                textAlign: "left", background: on ? H.surface : "transparent",
+                border: `1px solid ${on ? H.rule : "transparent"}`,
+                padding: "10px 14px", borderRadius: 12,
+                display: "flex", alignItems: "center", gap: 12,
+                boxShadow: on ? "0 1px 2px rgba(30,26,22,.04)" : "none",
+              }}>
+                <div style={{
+                  width: 8, height: 40, borderRadius: 4,
+                  background: on ? H.accent : H.rule, flexShrink: 0,
+                }}/>
+                <div style={{ flex: 1 }}>
+                  <div style={{ fontSize: 14, fontWeight: 500, color: H.ink }}>{b.device}</div>
+                  <div style={{ fontSize: 12, color: H.ink2, marginTop: 2 }}>
+                    {b.owner} · <span style={{ fontFamily: HF.mono }}>{b.lastBackup}</span>
+                  </div>
+                </div>
+                <Icons.Chevron size={13} stroke={on ? H.accent : H.ink3} strokeWidth={1.7}/>
+              </button>
+            );
+          })}
+        </div>
+
+        <div style={{
+          marginTop: "auto", paddingTop: 24, fontSize: 12, color: H.ink3,
+          display: "flex", alignItems: "center", gap: 8,
+        }}>
+          <Icons.Shield size={14} strokeWidth={1.5} stroke={H.sage}/>
+          Nothing leaves your computer.
+        </div>
+      </div>
+
+      {/* Right: photo-card stack */}
+      <div style={{
+        flex: 1, position: "relative", overflow: "hidden",
+        background: `radial-gradient(ellipse at 60% 20%, #faecdc 0%, ${H.bg} 60%)`,
+      }}>
+        {backups.map((b, i) => {
+          const offset = i - sel;
+          const active = offset === 0;
+          const rotate = offset === 0 ? -2 : offset === 1 ? 4 : offset === 2 ? -6 : 0;
+          const translateX = offset * 30;
+          const translateY = offset === 0 ? 0 : 20 + Math.abs(offset) * 14;
+          const scale = active ? 1 : 0.96 - Math.abs(offset) * 0.02;
+          const z = 10 - Math.abs(offset);
+          return (
+            <div key={b.id} style={{
+              position: "absolute",
+              top: "50%", left: "50%",
+              width: 360, height: 450,
+              background: H.surface,
+              borderRadius: 14,
+              border: `1px solid ${H.rule}`,
+              boxShadow: active
+                ? "0 24px 60px rgba(30,26,22,.18), 0 2px 6px rgba(30,26,22,.06)"
+                : "0 10px 30px rgba(30,26,22,.12)",
+              transform: `translate(-50%, -50%) translate(${translateX}px, ${translateY}px) rotate(${rotate}deg) scale(${scale})`,
+              zIndex: z,
+              padding: 14,
+              transition: "transform .4s cubic-bezier(.2,.8,.2,1), box-shadow .4s",
+            }}>
+              {/* Polaroid image */}
+              <div style={{
+                width: "100%", height: 300, borderRadius: 8, overflow: "hidden",
+                background: `
+                  linear-gradient(135deg, rgba(217,119,87,.25), rgba(122,154,122,.25)),
+                  repeating-linear-gradient(45deg, #e8d8c0 0 8px, #dec7a8 8px 16px)
+                `,
+                position: "relative",
+              }}>
+                {/* phone silhouette */}
+                <div style={{
+                  position: "absolute", left: "50%", top: "50%",
+                  transform: "translate(-50%,-50%)",
+                  width: 120, height: 220, borderRadius: 22,
+                  background: "rgba(30,26,22,.86)",
+                  border: "3px solid rgba(255,255,255,.3)",
+                }}>
+                  <div style={{
+                    margin: "6px auto 0", width: 38, height: 14, borderRadius: 10,
+                    background: "rgba(0,0,0,.5)",
+                  }}/>
+                </div>
+                <div style={{
+                  position: "absolute", left: 12, top: 12,
+                  fontFamily: HF.mono, fontSize: 10, color: "rgba(30,26,22,.55)",
+                  letterSpacing: "0.08em",
+                }}>{b.lastBackup.toUpperCase()}</div>
+                <div style={{
+                  position: "absolute", right: 12, bottom: 12,
+                  fontFamily: HF.mono, fontSize: 10, color: "rgba(30,26,22,.55)",
+                  letterSpacing: "0.08em",
+                }}>{b.color.toUpperCase()}</div>
+              </div>
+
+              {/* Caption */}
+              <div style={{ padding: "14px 4px 4px" }}>
+                <div style={{ fontFamily: HF.serif, fontSize: 22, lineHeight: 1.15, fontWeight: 500 }}>
+                  {b.device}
+                </div>
+                <div style={{ fontSize: 12.5, color: H.ink2, marginTop: 3, fontStyle: "italic", fontFamily: HF.serif }}>
+                  "{b.owner}"
+                </div>
+
+                {active && (
+                  <>
+                    <div style={{
+                      display: "grid", gridTemplateColumns: "repeat(3,1fr)", gap: 8,
+                      marginTop: 14,
+                    }}>
+                      {[
+                        ["Photos",   b.photos.toLocaleString()],
+                        ["Messages", b.messages.toLocaleString()],
+                        ["Voicemail", b.voicemails],
+                      ].map(([k, v]) => (
+                        <div key={k} style={{
+                          background: H.sand, borderRadius: 8, padding: "8px 10px",
+                        }}>
+                          <div style={{ fontFamily: HF.mono, fontSize: 9.5, letterSpacing: "0.1em", color: H.ink3, textTransform: "uppercase" }}>{k}</div>
+                          <div style={{ fontFamily: HF.serif, fontSize: 18, fontWeight: 500, color: H.ink, marginTop: 2 }}>{v}</div>
+                        </div>
+                      ))}
+                    </div>
+                    <button style={{
+                      marginTop: 14, width: "100%",
+                      background: H.accent, color: "#fff", border: 0,
+                      padding: "11px 16px", borderRadius: 10,
+                      fontSize: 13.5, fontWeight: 500, letterSpacing: "-0.005em",
+                      display: "inline-flex", justifyContent: "center", alignItems: "center", gap: 8,
+                      boxShadow: "0 6px 18px rgba(217,119,87,.28)",
+                    }}>
+                      {b.encrypted && <Icons.Lock size={13} strokeWidth={1.8}/>}
+                      Open this backup
+                    </button>
+                  </>
+                )}
+              </div>
+            </div>
+          );
+        })}
+
+        {/* page dots */}
+        <div style={{
+          position: "absolute", bottom: 28, left: 0, right: 0,
+          display: "flex", justifyContent: "center", gap: 7,
+        }}>
+          {backups.map((_, i) => (
+            <div key={i} onClick={() => setSel(i)} style={{
+              width: i === sel ? 22 : 7, height: 7, borderRadius: 999,
+              background: i === sel ? H.accent : H.rule,
+              transition: "width .3s",
+            }}/>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+// --- MESSAGES ---
+const Hearth_Messages = () => {
+  const { conversations, activeThread } = window.OE_DATA;
+  const Icons = window.OEIcons;
+
+  return (
+    <div style={{ flex: 1, display: "flex", overflow: "hidden" }}>
+      {/* Conversation rail — people as portrait bubbles */}
+      <aside style={{
+        width: 310, flexShrink: 0, borderRight: `1px solid ${H.rule}`,
+        display: "flex", flexDirection: "column", background: H.bg,
+      }}>
+        <div style={{ padding: "22px 22px 14px" }}>
+          <h2 style={{ fontFamily: HF.serif, fontSize: 28, fontWeight: 500, margin: 0, letterSpacing: "-0.02em" }}>
+            People
+          </h2>
+          <div style={{ fontSize: 12.5, color: H.ink2, marginTop: 4 }}>
+            214 conversations, sorted by warmth
+          </div>
+          <div style={{
+            marginTop: 14, display: "flex", alignItems: "center", gap: 8,
+            background: H.surface, border: `1px solid ${H.rule}`, borderRadius: 999,
+            padding: "8px 14px",
+          }}>
+            <Icons.Search size={13} strokeWidth={1.6} stroke={H.ink3}/>
+            <span style={{ fontSize: 12.5, color: H.ink3 }}>Search people & messages</span>
+          </div>
+        </div>
+        <div style={{ overflow: "auto", padding: "4px 12px 14px", flex: 1 }}>
+          {conversations.map((c, i) => {
+            const on = c.id === activeThread.contactId;
+            const recent = i < 3;
+            return (
+              <div key={c.id} style={{
+                display: "flex", gap: 12, padding: "10px 10px",
+                borderRadius: 12,
+                background: on ? H.surface : "transparent",
+                border: `1px solid ${on ? H.rule : "transparent"}`,
+                marginBottom: 2, cursor: "pointer",
+                boxShadow: on ? "0 2px 10px rgba(30,26,22,.04)" : "none",
+              }}>
+                <div style={{ position: "relative", flexShrink: 0 }}>
+                  <div style={{
+                    width: 42, height: 42, borderRadius: "50%",
+                    background: `radial-gradient(circle at 35% 30%,
+                      oklch(85% 0.09 ${c.avatarHue}),
+                      oklch(70% 0.10 ${c.avatarHue}))`,
+                    display: "flex", alignItems: "center", justifyContent: "center",
+                    fontFamily: HF.serif, fontSize: 18, color: "#fff",
+                    boxShadow: recent ? `0 0 0 3px ${H.bg}, 0 0 0 4px rgba(217,119,87,.35)` : "none",
+                  }}>
+                    {c.name[0]}
+                  </div>
+                </div>
+                <div style={{ flex: 1, minWidth: 0 }}>
+                  <div style={{ display: "flex", justifyContent: "space-between", alignItems: "baseline" }}>
+                    <span style={{ fontSize: 13.5, fontWeight: 500, color: H.ink }}>{c.name}</span>
+                    <span style={{ fontSize: 10.5, color: H.ink3, fontFamily: HF.mono }}>{c.time}</span>
+                  </div>
+                  <div style={{
+                    fontSize: 12.5, color: H.ink2, marginTop: 2,
+                    whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis",
+                  }}>{c.preview}</div>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      </aside>
+
+      {/* Body */}
+      <section style={{ flex: 1, display: "flex", flexDirection: "column", minWidth: 0,
+                        background: `linear-gradient(180deg, ${H.bg}, #f8eee1)` }}>
+        <div style={{
+          padding: "18px 28px", borderBottom: `1px solid ${H.rule}`,
+          display: "flex", alignItems: "center", gap: 14,
+          background: H.bg,
+        }}>
+          <div style={{
+            width: 42, height: 42, borderRadius: "50%",
+            background: `radial-gradient(circle at 35% 30%, oklch(85% 0.09 14), oklch(70% 0.10 14))`,
+            display: "flex", alignItems: "center", justifyContent: "center",
+            fontFamily: HF.serif, fontSize: 18, color: "#fff",
+          }}>E</div>
+          <div style={{ flex: 1 }}>
+            <div style={{ fontFamily: HF.serif, fontSize: 22, fontWeight: 500, letterSpacing: "-0.02em" }}>Emma</div>
+            <div style={{ fontSize: 12, color: H.ink2, marginTop: 2 }}>
+              Daughter · 847 messages · first hello in 2016
+            </div>
+          </div>
+          <div style={{ display: "flex", gap: 8 }}>
+            <button style={{
+              background: "transparent", border: `1px solid ${H.rule}`, color: H.ink,
+              padding: "7px 12px", borderRadius: 999, fontSize: 12, display: "inline-flex", gap: 6, alignItems: "center",
+            }}>
+              <Icons.Image size={13} strokeWidth={1.6}/> Photos only
+            </button>
+            <button style={{
+              background: H.ink, color: H.bg, border: 0,
+              padding: "7px 14px", borderRadius: 999, fontSize: 12, display: "inline-flex", gap: 6, alignItems: "center",
+            }}>
+              <Icons.Export size={13} strokeWidth={1.7}/> Save thread
+            </button>
+          </div>
+        </div>
+
+        <div style={{ flex: 1, overflow: "auto", padding: "22px 40px 18px" }}>
+          <div style={{ textAlign: "center", margin: "0 0 18px", fontSize: 11.5, color: H.ink3, fontFamily: HF.mono, letterSpacing: "0.1em" }}>
+            MONDAY · AUG 14, 2023
+          </div>
+
+          {activeThread.messages.map(m => {
+            const mine = m.from === "me";
+            return (
+              <div key={m.id} style={{
+                display: "flex", justifyContent: mine ? "flex-end" : "flex-start",
+                marginBottom: 8, gap: 10,
+              }}>
+                {!mine && (
+                  <div style={{
+                    width: 30, height: 30, borderRadius: "50%", flexShrink: 0,
+                    background: `radial-gradient(circle at 35% 30%, oklch(85% 0.09 14), oklch(70% 0.10 14))`,
+                    alignSelf: "flex-end",
+                  }}/>
+                )}
+                <div style={{
+                  maxWidth: "62%",
+                  background: mine ? H.bubbleMe : H.bubbleThem,
+                  color: mine ? "#fff" : H.ink,
+                  padding: m.kind === "photo" ? 6 : "10px 15px",
+                  borderRadius: 20,
+                  borderBottomRightRadius: mine ? 6 : 20,
+                  borderBottomLeftRadius: mine ? 20 : 6,
+                  fontSize: 14.5, lineHeight: 1.42,
+                  boxShadow: mine ? "0 6px 18px rgba(217,119,87,.22)" : "0 1px 0 rgba(30,26,22,.04)",
+                }}>
+                  {m.kind === "photo" ? (
+                    <div>
+                      <div style={{
+                        width: 280, height: 200, borderRadius: 14, overflow: "hidden",
+                        background: `
+                          linear-gradient(135deg, rgba(217,119,87,.35), rgba(122,154,122,.25)),
+                          repeating-linear-gradient(45deg, #e3cfa8 0 10px, #d5bc8c 10px 20px)
+                        `,
+                        position: "relative",
+                      }}>
+                        <div style={{
+                          position: "absolute", inset: 0,
+                          background: "linear-gradient(180deg, rgba(0,0,0,0) 50%, rgba(0,0,0,.4))",
+                        }}/>
+                        <div style={{
+                          position: "absolute", left: 12, bottom: 10, right: 12,
+                          fontFamily: HF.mono, fontSize: 10.5, color: "#fff6e9",
+                          letterSpacing: "0.04em",
+                        }}>{m.caption}</div>
+                      </div>
+                    </div>
+                  ) : m.text}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+
+        {/* Time-slider ribbon along bottom */}
+        <div style={{
+          padding: "10px 28px 16px", borderTop: `1px solid ${H.rule}`,
+          display: "flex", alignItems: "center", gap: 14, background: H.bg,
+        }}>
+          <span style={{ fontFamily: HF.mono, fontSize: 10, color: H.ink3, letterSpacing: "0.1em" }}>2016</span>
+          <div style={{ flex: 1, position: "relative", height: 24 }}>
+            <div style={{ position: "absolute", inset: "10px 0", background: H.sand, borderRadius: 999 }}/>
+            {/* activity bars */}
+            <div style={{ position: "absolute", inset: 0, display: "flex", alignItems: "end", gap: 2 }}>
+              {Array.from({ length: 84 }).map((_, i) => {
+                const h = 6 + Math.abs(Math.sin(i * 0.42)) * 16 + (i > 70 ? 4 : 0);
+                return <div key={i} style={{
+                  flex: 1, height: h, background: i > 78 ? H.accent : "rgba(217,119,87,.45)",
+                  borderRadius: 2,
+                }}/>;
+              })}
+            </div>
+            <div style={{
+              position: "absolute", left: "92%", top: -4, width: 3, height: 32,
+              background: H.ink, borderRadius: 2,
+            }}/>
+          </div>
+          <span style={{ fontFamily: HF.mono, fontSize: 10, color: H.accent, letterSpacing: "0.1em" }}>AUG '23</span>
+        </div>
+      </section>
+    </div>
+  );
+};
+
+window.HearthRoot = ({ screen }) => {
+  if (screen === "backup") {
+    return (
+      <Hearth_Chrome>
+        <div style={{ flex: 1, display: "flex", minHeight: 0 }}>
+          <Hearth_Sidebar active="" />
+          <Hearth_Backup />
+        </div>
+      </Hearth_Chrome>
+    );
+  }
+  if (screen === "messages") {
+    return (
+      <Hearth_Chrome>
+        <div style={{ flex: 1, display: "flex", minHeight: 0 }}>
+          <Hearth_Sidebar active="messages" />
+          <Hearth_Messages />
+        </div>
+      </Hearth_Chrome>
+    );
+  }
+  const tokens = {
+    bg: H.bg, surface: H.surface, sunk: H.sand,
+    ink: H.ink, ink2: H.ink2, ink3: H.ink3,
+    rule: H.rule, ruleStr: H.rule,
+    accent: H.accent, accentW: "#f7e6d8",
+    sans: HF.sans, serif: HF.serif, mono: HF.mono,
+    titleSerif: true, titleWeight: 500, titleLetter: "-0.02em", radius: 10,
+    bubbleMe: H.bubbleMe, bubbleThem: H.bubbleThem,
+    chipActive: H.ink, chipActiveFg: H.bg, chipFg: H.ink2,
+  };
+  return window.SharedScreens.render({
+    screen, tokens,
+    Sidebar: () => <Hearth_Sidebar active={screen}/>,
+    Chrome: Hearth_Chrome,
+    backupComponent: Hearth_Backup, messagesComponent: Hearth_Messages,
+  });
+};

--- a/mockups/app/app-mockups/icons.jsx
+++ b/mockups/app/app-mockups/icons.jsx
@@ -1,0 +1,32 @@
+// Minimal shared inline SVG icon set so variants stay consistent in glyph shape.
+// Each icon takes { size?, stroke?, strokeWidth? }. Monochrome, currentColor.
+
+const Icon = ({ path, size = 16, stroke = "currentColor", strokeWidth = 1.5, fill = "none", children }) => (
+  <svg width={size} height={size} viewBox="0 0 24 24" fill={fill} stroke={stroke} strokeWidth={strokeWidth}
+       strokeLinecap="round" strokeLinejoin="round" style={{ flex: "0 0 auto" }}>
+    {path ? <path d={path} /> : children}
+  </svg>
+);
+
+const Icons = {
+  Clock:    (p) => <Icon {...p}><circle cx="12" cy="12" r="9"/><path d="M12 7v5l3 2"/></Icon>,
+  Message:  (p) => <Icon {...p} path="M21 12a8 8 0 0 1-11.6 7.1L4 20l.9-4.9A8 8 0 1 1 21 12z"/>,
+  Image:    (p) => <Icon {...p}><rect x="3" y="4" width="18" height="16" rx="2"/><circle cx="9" cy="10" r="1.5"/><path d="m4 18 5-5 4 4 3-3 4 4"/></Icon>,
+  Phone:    (p) => <Icon {...p} path="M22 16.9v2.9a2 2 0 0 1-2.2 2 19.8 19.8 0 0 1-8.6-3.1 19.5 19.5 0 0 1-6-6A19.8 19.8 0 0 1 2.1 4.2 2 2 0 0 1 4.1 2h3a2 2 0 0 1 2 1.7 12.8 12.8 0 0 0 .7 2.8 2 2 0 0 1-.5 2.1L8 9.9a16 16 0 0 0 6 6l1.3-1.3a2 2 0 0 1 2.1-.5 12.8 12.8 0 0 0 2.8.7A2 2 0 0 1 22 16.9z"/>,
+  Voicemail:(p) => <Icon {...p}><circle cx="6.5" cy="12" r="4"/><circle cx="17.5" cy="12" r="4"/><path d="M6.5 16h11"/></Icon>,
+  User:     (p) => <Icon {...p}><path d="M20 21a8 8 0 0 0-16 0"/><circle cx="12" cy="7" r="4"/></Icon>,
+  FileText: (p) => <Icon {...p}><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><path d="M14 2v6h6M9 13h6M9 17h4"/></Icon>,
+  Search:   (p) => <Icon {...p}><circle cx="11" cy="11" r="7"/><path d="m21 21-4.3-4.3"/></Icon>,
+  Lock:     (p) => <Icon {...p}><rect x="4" y="10" width="16" height="10" rx="2"/><path d="M8 10V7a4 4 0 0 1 8 0v3"/></Icon>,
+  Shield:   (p) => <Icon {...p} path="M12 3 4 6v6c0 5 3.5 8.5 8 9 4.5-.5 8-4 8-9V6z"/>,
+  ArrowRight:(p)=> <Icon {...p}><path d="M5 12h14m-5-5 5 5-5 5"/></Icon>,
+  Download: (p) => <Icon {...p}><path d="M21 15v3a3 3 0 0 1-3 3H6a3 3 0 0 1-3-3v-3M7 10l5 5 5-5M12 15V3"/></Icon>,
+  Plus:     (p) => <Icon {...p}><path d="M12 5v14M5 12h14"/></Icon>,
+  Settings: (p) => <Icon {...p}><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.7 1.7 0 0 0 .3 1.9l.1.1a2 2 0 1 1-2.8 2.8l-.1-.1a1.7 1.7 0 0 0-1.9-.3 1.7 1.7 0 0 0-1 1.5V21a2 2 0 1 1-4 0v-.1a1.7 1.7 0 0 0-1.1-1.5 1.7 1.7 0 0 0-1.9.3l-.1.1a2 2 0 1 1-2.8-2.8l.1-.1a1.7 1.7 0 0 0 .3-1.9 1.7 1.7 0 0 0-1.5-1H3a2 2 0 1 1 0-4h.1a1.7 1.7 0 0 0 1.5-1.1 1.7 1.7 0 0 0-.3-1.9l-.1-.1a2 2 0 1 1 2.8-2.8l.1.1a1.7 1.7 0 0 0 1.9.3h.1a1.7 1.7 0 0 0 1-1.5V3a2 2 0 1 1 4 0v.1a1.7 1.7 0 0 0 1 1.5 1.7 1.7 0 0 0 1.9-.3l.1-.1a2 2 0 1 1 2.8 2.8l-.1.1a1.7 1.7 0 0 0-.3 1.9v.1a1.7 1.7 0 0 0 1.5 1H21a2 2 0 1 1 0 4h-.1a1.7 1.7 0 0 0-1.5 1z"/></Icon>,
+  Chevron:  (p) => <Icon {...p}><path d="m9 6 6 6-6 6"/></Icon>,
+  Paperclip:(p) => <Icon {...p} path="m21 12-9 9a6 6 0 0 1-8.5-8.5l9-9a4 4 0 0 1 5.7 5.7l-9 9a2 2 0 0 1-2.8-2.8l8.5-8.5"/>,
+  Filter:   (p) => <Icon {...p} path="M22 3H2l8 9.5V20l4 2v-9.5z"/>,
+  Export:   (p) => <Icon {...p}><path d="M12 3v13M7 8l5-5 5 5"/><path d="M20 17v2a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2v-2"/></Icon>,
+};
+
+window.OEIcons = Icons;

--- a/mockups/app/app-mockups/ledger.jsx
+++ b/mockups/app/app-mockups/ledger.jsx
@@ -1,0 +1,560 @@
+// ======================================================================
+// LEDGER — Cool off-white, graphite, single teal accent.
+// Tabular density. Hairline rules. Small caps for labels.
+// Novel UX: Timeline as a horizontal ribbon (not a list) — a literal
+// scrollable river of events with year ticks above.
+// Messages scrubber: thin year axis with dotted month ticks.
+// ======================================================================
+
+const LG = {
+  // tokens for shared-screens
+  bg:       "#f6f7f5",
+  surface:  "#ffffff",
+  sunk:     "#eef0ed",
+  ink:      "#161a1a",
+  ink2:     "#4a5252",
+  ink3:     "#8a9292",
+  rule:     "#e3e6e1",
+  ruleStr:  "#d1d6d0",
+  accent:   "#2d7d7a",
+  accentW:  "#e3efee",
+  sans:     "'Inter', system-ui, sans-serif",
+  serif:    "'Newsreader', serif",
+  mono:     "'JetBrains Mono', monospace",
+  titleSerif: false,
+  titleWeight: 600,
+  titleLetter: "-0.02em",
+  radius:   4,
+  bubbleMe:  "#161a1a",
+  bubbleThem:"#eef0ed",
+  chipActive: "#161a1a",
+  chipActiveFg: "#f6f7f5",
+  chipFg: "#4a5252",
+};
+
+const LedgerChrome = ({ children }) => (
+  <div style={{
+    background: LG.bg, color: LG.ink, height: "100%",
+    fontFamily: LG.sans, display: "flex", flexDirection: "column",
+  }}>
+    <div style={{
+      height: 42, display: "flex", alignItems: "center", padding: "0 14px",
+      background: LG.bg, borderBottom: `1px solid ${LG.rule}`, flexShrink: 0,
+    }}>
+      <div className="tl"><span className="r"/><span className="y"/><span className="g"/></div>
+      <div style={{ marginLeft: 16, fontSize: 12.5, fontWeight: 600, letterSpacing: "-0.01em" }}>OpenExtract</div>
+      <span style={{ width: 1, height: 14, background: LG.rule, margin: "0 14px" }}/>
+      <span style={{ fontSize: 11.5, color: LG.ink2, fontFamily: LG.mono }}>
+        mom_iphone13pro_2023-08-14.backup
+      </span>
+      <div style={{ flex: 1 }}/>
+      <span style={{ fontSize: 10.5, color: LG.ink3, fontFamily: LG.mono, letterSpacing: "0.08em", textTransform: "uppercase" }}>
+        Local · Read-only
+      </span>
+    </div>
+    {children}
+  </div>
+);
+
+const LedgerSidebar = ({ active }) => {
+  const Icons = window.OEIcons;
+  const items = [
+    { id: "timeline",  label: "Timeline",  I: Icons.Clock,     c: 65396 },
+    { id: "messages",  label: "Messages",  I: Icons.Message,   c: 48213 },
+    { id: "photos",    label: "Photos",    I: Icons.Image,     c: 12847 },
+    { id: "voicemail", label: "Voicemail", I: Icons.Voicemail, c: 24 },
+    { id: "calls",     label: "Calls",     I: Icons.Phone,     c: 4281 },
+    { id: "contacts",  label: "Contacts",  I: Icons.User,      c: 612 },
+    { id: "notes",     label: "Notes",     I: Icons.FileText,  c: 189 },
+  ];
+  return (
+    <nav style={{
+      width: 208, flexShrink: 0, padding: "14px 8px",
+      borderRight: `1px solid ${LG.rule}`, background: LG.bg,
+      display: "flex", flexDirection: "column",
+    }}>
+      <div style={{
+        fontSize: 10, color: LG.ink3, letterSpacing: "0.1em",
+        textTransform: "uppercase", padding: "4px 10px 8px", fontWeight: 600,
+      }}>Data</div>
+      {items.map(it => {
+        const on = it.id === active;
+        const I = it.I;
+        return (
+          <div key={it.id} style={{
+            display: "grid", gridTemplateColumns: "18px 1fr auto", alignItems: "center",
+            gap: 9, padding: "6px 10px", borderRadius: 4, cursor: "pointer",
+            color: on ? LG.ink : LG.ink2,
+            background: on ? LG.accentW : "transparent",
+            borderLeft: on ? `2px solid ${LG.accent}` : "2px solid transparent",
+            marginLeft: on ? 0 : 2,
+          }}>
+            <I size={14} strokeWidth={1.6} stroke={on ? LG.accent : LG.ink2}/>
+            <span style={{ fontSize: 12.5, fontWeight: on ? 500 : 400, letterSpacing: "-0.005em" }}>{it.label}</span>
+            <span style={{ fontSize: 10, fontFamily: LG.mono, color: LG.ink3 }}>{it.c.toLocaleString()}</span>
+          </div>
+        );
+      })}
+      <div style={{ flex: 1 }}/>
+      <div style={{
+        padding: "10px 10px 4px", fontSize: 10.5, color: LG.ink3, lineHeight: 1.5,
+        borderTop: `1px solid ${LG.rule}`, marginTop: 10, fontFamily: LG.mono,
+      }}>
+        BACKUP: iPhone 13 Pro<br/>
+        OWNER: Mom<br/>
+        SIZE: 84.2 GB · encrypted
+      </div>
+    </nav>
+  );
+};
+
+// --- Backup picker: tabular ---
+const LedgerBackup = () => {
+  const backups = window.OE_DATA.backups;
+  const Icons = window.OEIcons;
+
+  return (
+    <div style={{ flex: 1, overflow: "auto", background: LG.bg }}>
+      <div style={{ padding: "40px 44px 18px" }}>
+        <div style={{
+          fontSize: 10, color: LG.ink3, letterSpacing: "0.14em",
+          textTransform: "uppercase", fontWeight: 600,
+        }}>§ Step 1 — Select source</div>
+        <h1 style={{
+          margin: "10px 0 6px", fontSize: 32, fontWeight: 600,
+          letterSpacing: "-0.025em", lineHeight: 1.05,
+        }}>Three backups on this Mac.</h1>
+        <p style={{
+          margin: "6px 0 0", fontSize: 13.5, color: LG.ink2,
+          maxWidth: 600, lineHeight: 1.6,
+        }}>
+          A plain ledger of what we found. Pick one to open — nothing leaves this machine.
+        </p>
+      </div>
+
+      <div style={{ padding: "0 44px 44px" }}>
+        {/* Table */}
+        <div style={{
+          background: LG.surface, border: `1px solid ${LG.rule}`, borderRadius: 4,
+          overflow: "hidden",
+        }}>
+          <div style={{
+            display: "grid",
+            gridTemplateColumns: "34px 1.6fr 1fr 1fr 110px 120px",
+            padding: "10px 18px", background: LG.sunk,
+            borderBottom: `1px solid ${LG.rule}`,
+            fontSize: 10, color: LG.ink3, letterSpacing: "0.1em",
+            textTransform: "uppercase", fontWeight: 600,
+          }}>
+            <div>№</div><div>Device</div><div>Period</div><div>Contents</div>
+            <div style={{ textAlign: "right" }}>Size</div>
+            <div></div>
+          </div>
+          {backups.map((b, i) => (
+            <div key={b.id} style={{
+              display: "grid",
+              gridTemplateColumns: "34px 1.6fr 1fr 1fr 110px 120px",
+              padding: "18px 18px", alignItems: "center",
+              borderBottom: i === backups.length - 1 ? "none" : `1px solid ${LG.rule}`,
+              gap: 10,
+            }}>
+              <div style={{ fontFamily: LG.mono, fontSize: 12, color: LG.ink3 }}>0{i+1}</div>
+              <div>
+                <div style={{ fontSize: 14, fontWeight: 600, letterSpacing: "-0.005em" }}>{b.device}</div>
+                <div style={{ fontSize: 12, color: LG.ink2, marginTop: 1 }}>{b.owner} · {b.ios}</div>
+              </div>
+              <div style={{ fontFamily: LG.mono, fontSize: 12, color: LG.ink2 }}>
+                {b.years[0]}–{b.years[b.years.length - 1]}
+                <div style={{ fontSize: 10.5, color: LG.ink3, marginTop: 2 }}>last: {b.lastBackup}</div>
+              </div>
+              <div style={{ fontSize: 12, color: LG.ink2, lineHeight: 1.5 }}>
+                <div><span style={{ fontFamily: LG.mono, color: LG.ink }}>{b.messages.toLocaleString()}</span> msgs · <span style={{ fontFamily: LG.mono, color: LG.ink }}>{b.photos.toLocaleString()}</span> photos</div>
+                <div><span style={{ fontFamily: LG.mono, color: LG.ink }}>{b.calls.toLocaleString()}</span> calls · <span style={{ fontFamily: LG.mono, color: LG.ink }}>{b.voicemails}</span> vm</div>
+              </div>
+              <div style={{ fontFamily: LG.mono, fontSize: 12, color: LG.ink, textAlign: "right" }}>
+                {b.size}
+                <div style={{ fontSize: 10, color: LG.ink3, marginTop: 2, display: "flex", justifyContent: "flex-end", alignItems: "center", gap: 4 }}>
+                  {b.encrypted && <Icons.Lock size={10} strokeWidth={1.7}/>} {b.encrypted ? "encrypted" : "plain"}
+                </div>
+              </div>
+              <div style={{ display: "flex", justifyContent: "flex-end" }}>
+                <button style={{
+                  background: i === 0 ? LG.accent : "transparent",
+                  color: i === 0 ? "#fff" : LG.ink,
+                  border: `1px solid ${i === 0 ? LG.accent : LG.rule}`,
+                  padding: "7px 12px", borderRadius: 4,
+                  fontSize: 12, fontWeight: 500, fontFamily: LG.sans,
+                  display: "inline-flex", gap: 5, alignItems: "center",
+                }}>
+                  Open <Icons.ArrowRight size={11} strokeWidth={2}/>
+                </button>
+              </div>
+            </div>
+          ))}
+        </div>
+
+        <div style={{ marginTop: 14, display: "flex", alignItems: "center", gap: 10, fontSize: 12, color: LG.ink2 }}>
+          <button style={{
+            background: "transparent", border: `1px solid ${LG.rule}`,
+            padding: "7px 11px", borderRadius: 4, fontSize: 12, color: LG.ink,
+            display: "inline-flex", gap: 6, alignItems: "center", fontFamily: LG.sans,
+          }}>
+            <Icons.Plus size={11} strokeWidth={1.8}/> Open a folder…
+          </button>
+          <span>— or drag a backup onto the window.</span>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+// --- Messages with thin year axis scrubber ---
+const LedgerMessages = () => {
+  const { conversations, activeThread } = window.OE_DATA;
+  const Icons = window.OEIcons;
+  const years = [2016, 2017, 2018, 2019, 2020, 2021, 2022, 2023];
+
+  return (
+    <div style={{ flex: 1, display: "flex", overflow: "hidden", background: LG.bg, minWidth: 0 }}>
+      {/* conversation list */}
+      <aside style={{
+        width: 278, flexShrink: 0, borderRight: `1px solid ${LG.rule}`,
+        display: "flex", flexDirection: "column", background: LG.bg,
+      }}>
+        <div style={{ padding: "14px 16px 8px", display: "flex", flexDirection: "column", gap: 8 }}>
+          <h2 style={{ margin: 0, fontSize: 15, fontWeight: 600, letterSpacing: "-0.01em" }}>Messages · 214 threads</h2>
+          <div style={{
+            display: "flex", alignItems: "center", gap: 8,
+            background: LG.surface, border: `1px solid ${LG.rule}`, borderRadius: 4,
+            padding: "6px 9px",
+          }}>
+            <Icons.Search size={12} strokeWidth={1.6} stroke={LG.ink3}/>
+            <span style={{ fontSize: 12, color: LG.ink3 }}>Find a person…</span>
+            <span style={{ marginLeft: "auto", fontFamily: LG.mono, fontSize: 9.5, color: LG.ink3,
+                           background: LG.sunk, padding: "1px 5px", borderRadius: 3 }}>⌘F</span>
+          </div>
+        </div>
+        <div style={{ overflow: "auto", flex: 1, padding: "2px 6px 12px" }}>
+          {conversations.map(c => {
+            const on = c.id === activeThread.contactId;
+            return (
+              <div key={c.id} style={{
+                display: "flex", gap: 10, padding: "9px 10px",
+                borderRadius: 4, cursor: "pointer",
+                background: on ? LG.accentW : "transparent",
+                borderLeft: on ? `2px solid ${LG.accent}` : "2px solid transparent",
+                marginLeft: on ? 0 : 2,
+              }}>
+                <div style={{
+                  width: 30, height: 30, borderRadius: "50%", flexShrink: 0,
+                  background: `oklch(88% 0.04 ${c.avatarHue})`,
+                  border: `1px solid ${LG.rule}`,
+                  display: "flex", alignItems: "center", justifyContent: "center",
+                  fontSize: 12, color: LG.ink, fontWeight: 500,
+                }}>{c.name[0]}</div>
+                <div style={{ flex: 1, minWidth: 0 }}>
+                  <div style={{ display: "flex", justifyContent: "space-between", alignItems: "baseline" }}>
+                    <span style={{ fontSize: 12.5, color: LG.ink, fontWeight: on ? 600 : 500 }}>{c.name}</span>
+                    <span style={{ fontSize: 10, color: LG.ink3, fontFamily: LG.mono }}>{c.time}</span>
+                  </div>
+                  <div style={{
+                    fontSize: 11.5, color: LG.ink2, marginTop: 1,
+                    whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis",
+                  }}>{c.preview}</div>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      </aside>
+
+      {/* thread + scrubber */}
+      <section style={{ flex: 1, display: "flex", flexDirection: "column", minWidth: 0 }}>
+        <div style={{
+          padding: "12px 22px", borderBottom: `1px solid ${LG.rule}`,
+          display: "flex", alignItems: "center", gap: 12,
+        }}>
+          <div style={{
+            width: 32, height: 32, borderRadius: "50%",
+            background: "oklch(88% 0.04 14)", border: `1px solid ${LG.rule}`,
+            display: "flex", alignItems: "center", justifyContent: "center",
+            fontSize: 13, fontWeight: 500,
+          }}>E</div>
+          <div style={{ flex: 1 }}>
+            <div style={{ fontSize: 14, fontWeight: 600 }}>Emma</div>
+            <div style={{ fontSize: 11, color: LG.ink3, fontFamily: LG.mono, marginTop: 1 }}>
+              847 msgs · 2016–2023
+            </div>
+          </div>
+          <button style={{
+            background: "transparent", border: `1px solid ${LG.rule}`,
+            padding: "6px 10px", borderRadius: 4, fontSize: 11.5, color: LG.ink,
+            display: "inline-flex", gap: 5, alignItems: "center",
+          }}>
+            <Icons.Filter size={11} strokeWidth={1.6}/> Filter
+          </button>
+          <button style={{
+            background: LG.accent, color: "#fff", border: 0,
+            padding: "6px 11px", borderRadius: 4, fontSize: 11.5, fontWeight: 500,
+            display: "inline-flex", gap: 5, alignItems: "center",
+          }}>
+            <Icons.Export size={11} strokeWidth={1.8}/> Export
+          </button>
+        </div>
+
+        {/* SCRUBBER: thin year axis with dotted ticks */}
+        <div style={{
+          padding: "14px 32px 12px", borderBottom: `1px solid ${LG.rule}`,
+          background: LG.bg,
+        }}>
+          <div style={{ position: "relative", height: 36 }}>
+            {/* axis */}
+            <div style={{
+              position: "absolute", left: 0, right: 0, top: 18, height: 1,
+              background: LG.ruleStr,
+            }}/>
+            {/* year ticks */}
+            {years.map((y, i) => {
+              const x = (i / (years.length - 1)) * 100;
+              const active = y === 2023;
+              return (
+                <div key={y} style={{
+                  position: "absolute", left: `${x}%`, top: 0,
+                  transform: "translateX(-50%)",
+                  display: "flex", flexDirection: "column", alignItems: "center", gap: 4,
+                }}>
+                  <span style={{
+                    fontSize: 10, fontFamily: LG.mono, color: active ? LG.accent : LG.ink3,
+                    fontWeight: active ? 600 : 400,
+                  }}>{y}</span>
+                  <span style={{
+                    width: 1, height: 8,
+                    background: active ? LG.accent : LG.ink3,
+                  }}/>
+                </div>
+              );
+            })}
+            {/* month dots */}
+            {Array.from({ length: 84 }).map((_, i) => {
+              const x = (i / 83) * 100;
+              return (
+                <span key={i} style={{
+                  position: "absolute", left: `${x}%`, top: 30,
+                  transform: "translateX(-50%)",
+                  width: 2, height: 2, borderRadius: 99,
+                  background: i === 80 ? LG.accent : LG.ink3,
+                  opacity: i === 80 ? 1 : 0.3,
+                }}/>
+              );
+            })}
+            {/* current position handle */}
+            <div style={{
+              position: "absolute", left: "95.2%", top: 14, transform: "translateX(-50%)",
+              width: 8, height: 8, borderRadius: 99, background: LG.accent,
+              boxShadow: `0 0 0 4px ${LG.accentW}`,
+            }}/>
+          </div>
+          <div style={{
+            display: "flex", justifyContent: "space-between",
+            fontSize: 10.5, color: LG.ink3, fontFamily: LG.mono, marginTop: 4,
+          }}>
+            <span>viewing Aug 2023</span>
+            <span>drag to scrub · 847 events on axis</span>
+          </div>
+        </div>
+
+        <div style={{ flex: 1, overflow: "auto", padding: "22px 32px 22px" }}>
+          <div style={{
+            textAlign: "center", fontSize: 10.5, color: LG.ink3, fontFamily: LG.mono,
+            letterSpacing: "0.1em", marginBottom: 14, textTransform: "uppercase",
+          }}>— Monday · Aug 14, 2023 · 2:02 PM —</div>
+          {activeThread.messages.map(m => {
+            const mine = m.from === "me";
+            return (
+              <div key={m.id} style={{
+                display: "flex", justifyContent: mine ? "flex-end" : "flex-start",
+                marginBottom: 5,
+              }}>
+                <div style={{
+                  maxWidth: "62%",
+                  background: mine ? LG.bubbleMe : LG.bubbleThem,
+                  color: mine ? LG.bg : LG.ink,
+                  padding: m.kind === "photo" ? 4 : "8px 12px",
+                  borderRadius: 10,
+                  border: mine ? "none" : `1px solid ${LG.rule}`,
+                  fontSize: 13.5, lineHeight: 1.42, letterSpacing: "-0.005em",
+                }}>
+                  {m.kind === "photo" ? (
+                    <div style={{
+                      width: 220, height: 160, borderRadius: 7, overflow: "hidden",
+                      background: `
+                        linear-gradient(135deg, oklch(78% 0.06 45) 0%, oklch(55% 0.09 30) 100%),
+                        repeating-linear-gradient(45deg, rgba(255,255,255,.08) 0 10px, rgba(0,0,0,.08) 10px 20px)
+                      `, position: "relative",
+                    }}>
+                      <div style={{
+                        position: "absolute", left: 8, bottom: 6, right: 8,
+                        fontSize: 10, color: "#fff", fontFamily: LG.mono,
+                      }}>{m.caption}</div>
+                    </div>
+                  ) : m.text}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      </section>
+    </div>
+  );
+};
+
+// --- Novel TIMELINE: horizontal ribbon river ---
+const LedgerTimelineRibbon = () => {
+  const Icons = window.OEIcons;
+  const events = window.OE_DATA.timeline;
+  const typeColor = { photo: 45, message: 220, call: 200, voicemail: 180, note: 80 };
+  const typeGlyph = { photo: "◨", message: "▪", call: "●", voicemail: "◇", note: "▲" };
+
+  // lay out events on a horizontal axis — newest at right
+  const w = 1000;
+  const h = 300;
+  const lanes = { photo: 60, message: 110, call: 160, voicemail: 210, note: 260 };
+
+  return (
+    <div style={{ flex: 1, display: "flex", flexDirection: "column", background: LG.bg, minWidth: 0 }}>
+      <div style={{
+        padding: "20px 28px 14px", borderBottom: `1px solid ${LG.rule}`,
+        display: "flex", alignItems: "flex-end", gap: 16, flexShrink: 0,
+      }}>
+        <div style={{ flex: 1 }}>
+          <div style={{ fontSize: 10, color: LG.ink3, letterSpacing: "0.1em", textTransform: "uppercase", fontWeight: 600 }}>
+            Timeline · river view
+          </div>
+          <h1 style={{ margin: "6px 0 0", fontSize: 24, fontWeight: 600, letterSpacing: "-0.02em" }}>
+            Scroll the whole backup, like a river.
+          </h1>
+        </div>
+        <div style={{ display: "flex", gap: 6 }}>
+          <button style={{ fontSize: 11.5, padding: "5px 10px", borderRadius: 4,
+                           background: LG.ink, color: "#fff", border: 0 }}>Ribbon</button>
+          <button style={{ fontSize: 11.5, padding: "5px 10px", borderRadius: 4,
+                           background: "transparent", color: LG.ink2, border: `1px solid ${LG.rule}` }}>List</button>
+        </div>
+      </div>
+
+      <div style={{ flex: 1, overflow: "auto", padding: "28px 28px" }}>
+        <div style={{
+          background: LG.surface, border: `1px solid ${LG.rule}`,
+          borderRadius: 4, padding: "18px 18px 14px", overflow: "auto",
+        }}>
+          <svg viewBox={`0 0 ${w} ${h}`} width="100%" height={h} style={{ display: "block" }}>
+            {/* lane labels */}
+            {Object.entries(lanes).map(([k, y]) => (
+              <g key={k}>
+                <line x1={120} x2={w - 20} y1={y} y2={y} stroke={LG.rule} strokeDasharray="2 4"/>
+                <text x={12} y={y + 4} fontSize="10" fontFamily={LG.mono} fill={LG.ink3}
+                      letterSpacing="0.1em" textTransform="uppercase">
+                  {k.toUpperCase()}
+                </text>
+              </g>
+            ))}
+            {/* month axis top */}
+            {["Jun", "Jul 28", "Aug 04", "Aug 09", "Aug 11", "Aug 13", "Aug 14"].map((lbl, i, arr) => {
+              const x = 140 + (i / (arr.length - 1)) * (w - 180);
+              return (
+                <g key={i}>
+                  <line x1={x} x2={x} y1={30} y2={h - 20} stroke={LG.rule} strokeWidth={0.6}/>
+                  <text x={x} y={22} fontSize="10" fontFamily={LG.mono} fill={LG.ink3} textAnchor="middle">{lbl}</text>
+                </g>
+              );
+            })}
+            {/* events */}
+            {events.slice().reverse().map((e, i, arr) => {
+              const x = 140 + (i / (arr.length - 1)) * (w - 180);
+              const y = lanes[e.type];
+              const c = `oklch(52% 0.12 ${typeColor[e.type]})`;
+              return (
+                <g key={i}>
+                  <circle cx={x} cy={y} r={7} fill={c} opacity={0.18}/>
+                  <circle cx={x} cy={y} r={3.5} fill={c}/>
+                  {i % 2 === 0 && (
+                    <text x={x} y={y - 12} fontSize="9.5" fontFamily={LG.sans} fill={LG.ink2} textAnchor="middle">
+                      {e.title.length > 22 ? e.title.slice(0, 22) + "…" : e.title}
+                    </text>
+                  )}
+                </g>
+              );
+            })}
+          </svg>
+        </div>
+
+        {/* legend + count */}
+        <div style={{
+          marginTop: 14, display: "flex", alignItems: "center", gap: 16,
+          fontSize: 11, color: LG.ink2, fontFamily: LG.mono,
+        }}>
+          {Object.entries(typeColor).map(([k, h]) => (
+            <span key={k} style={{ display: "inline-flex", alignItems: "center", gap: 5 }}>
+              <span style={{ width: 8, height: 8, borderRadius: 99, background: `oklch(52% 0.12 ${h})` }}/>
+              {k}
+            </span>
+          ))}
+          <span style={{ marginLeft: "auto", color: LG.ink3 }}>65,396 events across 7 years</span>
+        </div>
+
+        {/* last events as a mini-list */}
+        <div style={{ marginTop: 22, fontSize: 10.5, color: LG.ink3, letterSpacing: "0.1em",
+                       textTransform: "uppercase", fontWeight: 600, marginBottom: 8 }}>
+          Most recent
+        </div>
+        <div style={{
+          background: LG.surface, border: `1px solid ${LG.rule}`, borderRadius: 4,
+          overflow: "hidden",
+        }}>
+          {events.slice(0, 5).map((e, i) => (
+            <div key={i} style={{
+              display: "grid", gridTemplateColumns: "90px 90px 1fr auto",
+              padding: "10px 16px", gap: 12, alignItems: "center",
+              borderBottom: i === 4 ? "none" : `1px solid ${LG.rule}`,
+              fontSize: 12.5,
+            }}>
+              <span style={{ fontFamily: LG.mono, fontSize: 11, color: LG.ink3 }}>{e.date}</span>
+              <span style={{ fontFamily: LG.mono, fontSize: 11, color: LG.ink3 }}>{e.time}</span>
+              <span><b style={{ fontWeight: 600 }}>{e.title}</b> <span style={{ color: LG.ink2 }}>· {e.meta}</span></span>
+              <span style={{ fontSize: 10, color: LG.ink3, fontFamily: LG.mono, letterSpacing: "0.08em", textTransform: "uppercase" }}>{e.type}</span>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+window.LedgerRoot = ({ screen }) => {
+  const body = () => {
+    switch (screen) {
+      case "backup":   return <LedgerBackup/>;
+      case "messages": return <LedgerMessages/>;
+      case "timeline": return <LedgerTimelineRibbon/>;
+      default: break;
+    }
+    // shared fallback
+    return null;
+  };
+
+  const sharedBody = body();
+  if (sharedBody) {
+    return (
+      <LedgerChrome>
+        <div style={{ flex: 1, display: "flex", minHeight: 0 }}>
+          {screen !== "backup" && <LedgerSidebar active={screen}/>}
+          {sharedBody}
+        </div>
+      </LedgerChrome>
+    );
+  }
+  return window.SharedScreens.render({
+    screen, tokens: LG, Sidebar: LedgerSidebar, Chrome: LedgerChrome,
+    backupComponent: LedgerBackup, messagesComponent: LedgerMessages,
+  });
+};

--- a/mockups/app/app-mockups/linen.jsx
+++ b/mockups/app/app-mockups/linen.jsx
@@ -1,0 +1,533 @@
+// ======================================================================
+// LINEN — Quiet minimal light
+// True neutral warm white, graphite text, single muted blue accent.
+// Inter + Newsreader (subtle serif accents only in numerals/titles).
+// Novel UX:
+//  · backup picker shows data-story row per backup with sparkline
+//  · messages view has a CALENDAR HEATMAP gutter on the right
+//    showing conversation activity per month, click to jump.
+// ======================================================================
+
+const L = {
+  bg:      "#fafaf8",
+  surface: "#ffffff",
+  sunk:    "#f4f3ef",
+  ink:     "#1a1a1a",
+  ink2:    "#585858",
+  ink3:    "#9a9a98",
+  rule:    "#ececea",
+  ruleStr: "#dededa",
+  accent:  "#4a6b8c",   // muted navy-blue
+  accentW: "#e8edf3",
+  bubbleMe: "#1a1a1a",
+  bubbleThem: "#f1f0ec",
+};
+const LF = {
+  serif: "'Newsreader', 'Instrument Serif', serif",
+  sans:  "'Inter', system-ui, sans-serif",
+  mono:  "'JetBrains Mono', monospace",
+};
+
+const Linen_Chrome = ({ children }) => (
+  <div style={{
+    background: L.bg, color: L.ink, height: "100%",
+    fontFamily: LF.sans, display: "flex", flexDirection: "column",
+  }}>
+    <div style={{
+      height: 44, display: "flex", alignItems: "center", padding: "0 16px",
+      background: L.bg, borderBottom: `1px solid ${L.rule}`, flexShrink: 0,
+    }}>
+      <div className="tl"><span className="r"/><span className="y"/><span className="g"/></div>
+      <div style={{ marginLeft: 16, fontSize: 13, fontWeight: 600, letterSpacing: "-0.01em" }}>
+        OpenExtract
+      </div>
+      <span style={{ width: 3, height: 3, borderRadius: 99, background: L.ink3, margin: "0 10px" }}/>
+      <span style={{ fontSize: 12, color: L.ink2 }}>Mom's phone · iPhone 13 Pro</span>
+      <div style={{ flex: 1 }}/>
+      <div style={{ display: "flex", alignItems: "center", gap: 10 }}>
+        <span style={{ fontSize: 11.5, color: L.ink3, fontFamily: LF.mono }}>
+          Local · Offline
+        </span>
+        <span style={{ width: 6, height: 6, borderRadius: 99, background: "#2f855a" }}/>
+      </div>
+    </div>
+    {children}
+  </div>
+);
+
+const Linen_Sidebar = ({ active }) => {
+  const Icons = window.OEIcons;
+  const items = [
+    { id: "timeline",  label: "Timeline",  I: Icons.Clock,     c: 4281 + 48213 + 12847 },
+    { id: "messages",  label: "Messages",  I: Icons.Message,   c: 48213 },
+    { id: "photos",    label: "Photos",    I: Icons.Image,     c: 12847 },
+    { id: "voicemail", label: "Voicemail", I: Icons.Voicemail, c: 24 },
+    { id: "calls",     label: "Calls",     I: Icons.Phone,     c: 4281 },
+    { id: "contacts",  label: "Contacts",  I: Icons.User,      c: 612 },
+    { id: "notes",     label: "Notes",     I: Icons.FileText,  c: 189 },
+  ];
+  return (
+    <nav style={{
+      width: 216, flexShrink: 0, padding: "18px 10px",
+      borderRight: `1px solid ${L.rule}`, background: L.bg,
+      display: "flex", flexDirection: "column",
+    }}>
+      <div style={{
+        fontSize: 11, color: L.ink3, letterSpacing: "0.06em",
+        textTransform: "uppercase", padding: "6px 10px 10px", fontWeight: 500,
+      }}>Data</div>
+      {items.map(it => {
+        const on = it.id === active;
+        const I = it.I;
+        return (
+          <div key={it.id} style={{
+            display: "flex", alignItems: "center", gap: 10,
+            padding: "7px 10px", borderRadius: 6, cursor: "pointer",
+            color: on ? L.ink : L.ink2,
+            background: on ? L.accentW : "transparent",
+            borderLeft: on ? `2px solid ${L.accent}` : "2px solid transparent",
+            marginLeft: on ? 0 : 2,
+          }}>
+            <I size={15} strokeWidth={1.5} stroke={on ? L.accent : L.ink2}/>
+            <span style={{ fontSize: 13, fontWeight: on ? 500 : 400, flex: 1, letterSpacing: "-0.005em" }}>{it.label}</span>
+            <span style={{
+              fontSize: 10.5, fontFamily: LF.mono, color: L.ink3,
+            }}>{it.c.toLocaleString()}</span>
+          </div>
+        );
+      })}
+      <div style={{ flex: 1 }}/>
+      <div style={{
+        padding: "12px 10px 4px", fontSize: 11, color: L.ink3, lineHeight: 1.45,
+        borderTop: `1px solid ${L.rule}`, marginTop: 12,
+      }}>
+        No account, no upload. Open source on GitHub.
+      </div>
+    </nav>
+  );
+};
+
+// --- BACKUP with mini sparkline per row ---
+const Linen_Backup = () => {
+  const backups = window.OE_DATA.backups;
+  const Icons = window.OEIcons;
+
+  const Sparkline = ({ values, color = L.accent }) => {
+    const w = 180, h = 36;
+    const max = Math.max(...values);
+    const step = w / (values.length - 1);
+    const path = values.map((v, i) => `${i === 0 ? "M" : "L"} ${(i * step).toFixed(1)} ${(h - (v / max) * (h - 4) - 2).toFixed(1)}`).join(" ");
+    const area = path + ` L ${w} ${h} L 0 ${h} Z`;
+    return (
+      <svg width={w} height={h} viewBox={`0 0 ${w} ${h}`} style={{ display: "block" }}>
+        <path d={area} fill={color} opacity={0.12}/>
+        <path d={path} fill="none" stroke={color} strokeWidth={1.5} strokeLinecap="round" strokeLinejoin="round"/>
+      </svg>
+    );
+  };
+
+  return (
+    <div style={{ flex: 1, overflow: "auto", background: L.bg }}>
+      <div style={{ padding: "48px 56px 24px" }}>
+        <div style={{ fontSize: 11, color: L.ink3, letterSpacing: "0.06em", textTransform: "uppercase" }}>
+          Step 1 of 1 · Choose a backup
+        </div>
+        <h1 style={{
+          margin: "10px 0 6px",
+          fontFamily: LF.serif, fontWeight: 400, fontSize: 44, letterSpacing: "-0.02em", lineHeight: 1.05,
+        }}>
+          Three backups on this Mac.
+        </h1>
+        <p style={{ maxWidth: 560, fontSize: 14, lineHeight: 1.6, color: L.ink2, margin: "6px 0 0" }}>
+          Listed newest first. Sparklines show monthly activity so you can see which period each backup covers before opening it.
+        </p>
+      </div>
+
+      <div style={{ padding: "0 56px 56px" }}>
+        <div style={{
+          background: L.surface, border: `1px solid ${L.rule}`, borderRadius: 10,
+          overflow: "hidden",
+        }}>
+          {/* header */}
+          <div style={{
+            display: "grid",
+            gridTemplateColumns: "1.6fr 1fr 200px 1fr 120px",
+            gap: 18, padding: "12px 22px",
+            borderBottom: `1px solid ${L.rule}`, background: L.sunk,
+            fontSize: 11, color: L.ink3, letterSpacing: "0.06em", textTransform: "uppercase", fontWeight: 500,
+          }}>
+            <div>Device</div>
+            <div>Period</div>
+            <div>Activity</div>
+            <div>Contents</div>
+            <div style={{ textAlign: "right" }}></div>
+          </div>
+
+          {backups.map((b, i) => (
+            <div key={b.id} style={{
+              display: "grid",
+              gridTemplateColumns: "1.6fr 1fr 200px 1fr 120px",
+              gap: 18, padding: "20px 22px", alignItems: "center",
+              borderBottom: i === backups.length - 1 ? "none" : `1px solid ${L.rule}`,
+            }}>
+              {/* device */}
+              <div>
+                <div style={{ display: "flex", alignItems: "center", gap: 10 }}>
+                  <div style={{
+                    width: 28, height: 40, borderRadius: 5,
+                    border: `1px solid ${L.ruleStr}`, background: L.sunk,
+                    position: "relative", flexShrink: 0,
+                  }}>
+                    <div style={{
+                      position: "absolute", inset: 3, borderRadius: 3,
+                      background: "linear-gradient(180deg, rgba(74,107,140,.3), rgba(74,107,140,.05))",
+                    }}/>
+                  </div>
+                  <div>
+                    <div style={{ fontSize: 14.5, fontWeight: 500, letterSpacing: "-0.005em" }}>{b.device}</div>
+                    <div style={{ fontSize: 12.5, color: L.ink2, marginTop: 1 }}>{b.owner}</div>
+                  </div>
+                </div>
+              </div>
+
+              {/* period */}
+              <div>
+                <div style={{ fontSize: 13.5, color: L.ink }}>{b.years[0]}–{b.years[b.years.length - 1]}</div>
+                <div style={{ fontSize: 11.5, color: L.ink3, marginTop: 2, fontFamily: LF.mono }}>
+                  Last backed up {b.lastBackup}
+                </div>
+              </div>
+
+              {/* sparkline */}
+              <div>
+                <Sparkline values={b.activity}/>
+                <div style={{ fontSize: 10.5, color: L.ink3, marginTop: 2, fontFamily: LF.mono, letterSpacing: "0.04em" }}>
+                  {b.activity.length} months · peak {Math.max(...b.activity)}/mo
+                </div>
+              </div>
+
+              {/* contents */}
+              <div style={{ display: "flex", flexDirection: "column", gap: 2, fontSize: 12, color: L.ink2 }}>
+                <div><span style={{ fontFamily: LF.mono, color: L.ink }}>{b.messages.toLocaleString()}</span> messages</div>
+                <div><span style={{ fontFamily: LF.mono, color: L.ink }}>{b.photos.toLocaleString()}</span> photos</div>
+                <div><span style={{ fontFamily: LF.mono, color: L.ink }}>{b.voicemails}</span> voicemails · <span style={{ fontFamily: LF.mono, color: L.ink }}>{b.calls.toLocaleString()}</span> calls</div>
+              </div>
+
+              {/* action */}
+              <div style={{ display: "flex", gap: 6, justifyContent: "flex-end" }}>
+                {b.encrypted && (
+                  <div title="Encrypted" style={{
+                    width: 32, height: 32, borderRadius: 6,
+                    border: `1px solid ${L.rule}`, display: "flex", alignItems: "center", justifyContent: "center",
+                    color: L.ink2,
+                  }}>
+                    <Icons.Lock size={13} strokeWidth={1.7}/>
+                  </div>
+                )}
+                <button style={{
+                  background: i === 0 ? L.ink : L.surface,
+                  color: i === 0 ? L.bg : L.ink,
+                  border: `1px solid ${i === 0 ? L.ink : L.rule}`,
+                  padding: "8px 14px", borderRadius: 6,
+                  fontSize: 12.5, fontWeight: 500, letterSpacing: "-0.005em",
+                  display: "inline-flex", alignItems: "center", gap: 6,
+                }}>
+                  Open
+                  <Icons.ArrowRight size={12} strokeWidth={2}/>
+                </button>
+              </div>
+            </div>
+          ))}
+        </div>
+
+        <div style={{
+          marginTop: 16, display: "flex", alignItems: "center", gap: 12,
+          fontSize: 12.5, color: L.ink2,
+        }}>
+          <button style={{
+            background: "transparent", border: `1px solid ${L.rule}`,
+            padding: "7px 12px", borderRadius: 6, fontSize: 12, color: L.ink,
+            display: "inline-flex", gap: 6, alignItems: "center",
+          }}>
+            <Icons.Plus size={12} strokeWidth={1.8}/>
+            Open a folder…
+          </button>
+          <span>or drag a backup folder onto this window.</span>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+// --- MESSAGES with calendar heatmap gutter ---
+const Linen_Messages = () => {
+  const { conversations, activeThread } = window.OE_DATA;
+  const Icons = window.OEIcons;
+  const years = [2019, 2020, 2021, 2022, 2023];
+  const months = ["J","F","M","A","M","J","J","A","S","O","N","D"];
+
+  // Deterministic "activity" per year/month — warmer in some years
+  const activity = (y, m) => {
+    const base = (y === 2023 ? 0.55 : y === 2022 ? 0.45 : y === 2021 ? 0.35 : y === 2020 ? 0.3 : 0.2);
+    const wave = 0.3 + Math.abs(Math.sin((y * 12 + m) * 0.9)) * 0.5;
+    const special = (y === 2023 && m === 7) ? 1 : (y === 2020 && m === 11) ? 0.95 : 0;
+    return Math.min(1, base + wave * 0.5 + special);
+  };
+  const heatColor = (v) => {
+    if (v < 0.12) return L.sunk;
+    const lightness = 96 - v * 50;
+    const chroma = 0.03 + v * 0.07;
+    return `oklch(${lightness}% ${chroma.toFixed(3)} 240)`;
+  };
+
+  return (
+    <div style={{ flex: 1, display: "flex", overflow: "hidden", background: L.bg }}>
+      {/* Conversation list */}
+      <aside style={{
+        width: 290, flexShrink: 0, borderRight: `1px solid ${L.rule}`,
+        display: "flex", flexDirection: "column", background: L.bg,
+      }}>
+        <div style={{ padding: "16px 18px 8px", display: "flex", flexDirection: "column", gap: 10 }}>
+          <h2 style={{ margin: 0, fontSize: 16, fontWeight: 600, letterSpacing: "-0.01em" }}>Messages</h2>
+          <div style={{
+            display: "flex", alignItems: "center", gap: 8,
+            background: L.surface, border: `1px solid ${L.rule}`, borderRadius: 6,
+            padding: "7px 10px",
+          }}>
+            <Icons.Search size={13} strokeWidth={1.6} stroke={L.ink3}/>
+            <span style={{ fontSize: 12.5, color: L.ink3 }}>Search in 214 threads</span>
+            <span style={{ marginLeft: "auto", fontFamily: LF.mono, fontSize: 10, color: L.ink3,
+                           background: L.sunk, padding: "1px 5px", borderRadius: 4 }}>⌘F</span>
+          </div>
+          <div style={{ display: "flex", gap: 4 }}>
+            {["All", "Unread", "Photos", "Pinned"].map((t, i) => (
+              <button key={t} style={{
+                fontSize: 11.5, padding: "4px 9px", borderRadius: 99,
+                background: i === 0 ? L.ink : "transparent",
+                color: i === 0 ? L.bg : L.ink2,
+                border: `1px solid ${i === 0 ? L.ink : L.rule}`,
+              }}>{t}</button>
+            ))}
+          </div>
+        </div>
+        <div style={{ overflow: "auto", flex: 1, padding: "4px 6px 12px" }}>
+          {conversations.map(c => {
+            const on = c.id === activeThread.contactId;
+            return (
+              <div key={c.id} style={{
+                display: "flex", gap: 10, padding: "9px 10px",
+                borderRadius: 6, cursor: "pointer",
+                background: on ? L.accentW : "transparent",
+                borderLeft: on ? `2px solid ${L.accent}` : "2px solid transparent",
+                marginLeft: on ? 0 : 2,
+              }}>
+                <div style={{
+                  width: 32, height: 32, borderRadius: "50%", flexShrink: 0,
+                  background: `oklch(88% 0.04 ${c.avatarHue})`,
+                  border: `1px solid ${L.rule}`,
+                  display: "flex", alignItems: "center", justifyContent: "center",
+                  fontSize: 12.5, color: L.ink, fontWeight: 500,
+                }}>{c.name[0]}</div>
+                <div style={{ flex: 1, minWidth: 0 }}>
+                  <div style={{ display: "flex", justifyContent: "space-between", alignItems: "baseline" }}>
+                    <span style={{ fontSize: 13, color: L.ink, fontWeight: on ? 600 : 500, letterSpacing: "-0.005em" }}>{c.name}</span>
+                    <span style={{ fontSize: 10.5, color: L.ink3, fontFamily: LF.mono }}>{c.time}</span>
+                  </div>
+                  <div style={{
+                    fontSize: 12, color: L.ink2, marginTop: 1,
+                    whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis",
+                  }}>{c.preview}</div>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      </aside>
+
+      {/* Thread body */}
+      <section style={{ flex: 1, display: "flex", flexDirection: "column", minWidth: 0, background: L.bg }}>
+        <div style={{
+          padding: "14px 24px", borderBottom: `1px solid ${L.rule}`,
+          display: "flex", alignItems: "center", gap: 12,
+        }}>
+          <div style={{
+            width: 36, height: 36, borderRadius: "50%",
+            background: "oklch(88% 0.04 14)", border: `1px solid ${L.rule}`,
+            display: "flex", alignItems: "center", justifyContent: "center",
+            fontSize: 14, fontWeight: 500,
+          }}>E</div>
+          <div style={{ flex: 1 }}>
+            <div style={{ fontSize: 14.5, fontWeight: 600 }}>Emma</div>
+            <div style={{ fontSize: 11.5, color: L.ink3, marginTop: 1, fontFamily: LF.mono }}>
+              847 messages · 2016–2023 · daughter
+            </div>
+          </div>
+          <button style={{
+            background: "transparent", border: `1px solid ${L.rule}`,
+            padding: "6px 11px", borderRadius: 6, fontSize: 12, color: L.ink,
+            display: "inline-flex", gap: 6, alignItems: "center",
+          }}>
+            <Icons.Filter size={12} strokeWidth={1.6}/> Filter
+          </button>
+          <button style={{
+            background: L.accent, color: "#fff", border: 0,
+            padding: "6px 12px", borderRadius: 6, fontSize: 12, fontWeight: 500,
+            display: "inline-flex", gap: 6, alignItems: "center",
+          }}>
+            <Icons.Export size={12} strokeWidth={1.8}/> Export
+          </button>
+        </div>
+
+        <div style={{ flex: 1, display: "flex", minHeight: 0 }}>
+          {/* Messages */}
+          <div style={{ flex: 1, overflow: "auto", padding: "22px 32px 22px" }}>
+            <div style={{
+              textAlign: "center", fontSize: 11.5, color: L.ink3, fontFamily: LF.mono,
+              letterSpacing: "0.08em", marginBottom: 16,
+            }}>
+              Monday · Aug 14, 2023 · 2:02 PM
+            </div>
+            {activeThread.messages.map(m => {
+              const mine = m.from === "me";
+              return (
+                <div key={m.id} style={{
+                  display: "flex", justifyContent: mine ? "flex-end" : "flex-start",
+                  marginBottom: 6,
+                }}>
+                  <div style={{
+                    maxWidth: "62%",
+                    background: mine ? L.bubbleMe : L.bubbleThem,
+                    color: mine ? L.bg : L.ink,
+                    padding: m.kind === "photo" ? 5 : "9px 13px",
+                    borderRadius: 14,
+                    border: mine ? "none" : `1px solid ${L.rule}`,
+                    fontSize: 14, lineHeight: 1.42, letterSpacing: "-0.005em",
+                  }}>
+                    {m.kind === "photo" ? (
+                      <div>
+                        <div style={{
+                          width: 240, height: 170, borderRadius: 10, overflow: "hidden",
+                          background: `
+                            linear-gradient(135deg, rgba(74,107,140,.18), rgba(90,140,110,.14)),
+                            repeating-linear-gradient(45deg, #e4e2dc 0 10px, #d8d6cf 10px 20px)
+                          `,
+                          position: "relative",
+                        }}>
+                          <div style={{
+                            position: "absolute", left: 10, bottom: 8, right: 10,
+                            fontFamily: LF.mono, fontSize: 10, color: "#2a2a2a",
+                            letterSpacing: "0.04em",
+                          }}>{m.caption}</div>
+                        </div>
+                      </div>
+                    ) : m.text}
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+
+          {/* Calendar heatmap gutter — novel bit */}
+          <aside style={{
+            width: 160, flexShrink: 0, borderLeft: `1px solid ${L.rule}`,
+            padding: "22px 16px", display: "flex", flexDirection: "column",
+            background: L.bg,
+          }}>
+            <div style={{ fontSize: 11, color: L.ink3, letterSpacing: "0.06em", textTransform: "uppercase", fontWeight: 500 }}>
+              Activity
+            </div>
+            <div style={{ fontSize: 11, color: L.ink3, marginTop: 4, fontFamily: LF.mono }}>click a cell</div>
+
+            <div style={{ marginTop: 16, display: "flex", flexDirection: "column", gap: 3 }}>
+              {/* header row: months */}
+              <div style={{ display: "grid", gridTemplateColumns: "30px repeat(12, 1fr)", gap: 2, alignItems: "center" }}>
+                <div/>
+                {months.map((m, i) => (
+                  <div key={i} style={{ fontSize: 8.5, color: L.ink3, textAlign: "center", fontFamily: LF.mono }}>{m}</div>
+                ))}
+              </div>
+              {years.map(y => (
+                <div key={y} style={{ display: "grid", gridTemplateColumns: "30px repeat(12, 1fr)", gap: 2, alignItems: "center" }}>
+                  <div style={{
+                    fontSize: 10, color: y === 2023 ? L.accent : L.ink3, fontFamily: LF.mono, fontWeight: y === 2023 ? 500 : 400,
+                  }}>{y}</div>
+                  {months.map((_, m) => {
+                    const v = activity(y, m);
+                    const current = (y === 2023 && m === 7);
+                    return (
+                      <div key={m} title={`${months[m]} ${y}`} style={{
+                        height: 14, borderRadius: 3,
+                        background: heatColor(v),
+                        border: current ? `1.5px solid ${L.accent}` : `1px solid ${L.rule}`,
+                      }}/>
+                    );
+                  })}
+                </div>
+              ))}
+            </div>
+
+            <div style={{
+              marginTop: 18, display: "flex", alignItems: "center", gap: 6,
+              fontSize: 10, color: L.ink3, fontFamily: LF.mono,
+            }}>
+              less
+              {[0.05, 0.25, 0.5, 0.75, 1].map(v => (
+                <div key={v} style={{ width: 10, height: 10, borderRadius: 2, background: heatColor(v), border: `1px solid ${L.rule}` }}/>
+              ))}
+              more
+            </div>
+
+            <div style={{ flex: 1 }}/>
+
+            <div style={{
+              fontSize: 11, color: L.ink2, lineHeight: 1.5,
+              paddingTop: 14, borderTop: `1px solid ${L.rule}`, marginTop: 14,
+            }}>
+              Highlighted: <span style={{ color: L.accent, fontWeight: 500 }}>Aug 2023</span>.
+              847 messages total with Emma between 2016 and 2023.
+            </div>
+          </aside>
+        </div>
+      </section>
+    </div>
+  );
+};
+
+window.LinenRoot = ({ screen }) => {
+  if (screen === "backup") {
+    return (
+      <Linen_Chrome>
+        <div style={{ flex: 1, display: "flex", minHeight: 0 }}>
+          <Linen_Sidebar active="" />
+          <Linen_Backup />
+        </div>
+      </Linen_Chrome>
+    );
+  }
+  if (screen === "messages") {
+    return (
+      <Linen_Chrome>
+        <div style={{ flex: 1, display: "flex", minHeight: 0 }}>
+          <Linen_Sidebar active="messages" />
+          <Linen_Messages />
+        </div>
+      </Linen_Chrome>
+    );
+  }
+  const tokens = {
+    bg: L.bg, surface: L.surface, sunk: L.sunk,
+    ink: L.ink, ink2: L.ink2, ink3: L.ink3,
+    rule: L.rule, ruleStr: L.ruleStr,
+    accent: L.accent, accentW: L.accentW,
+    sans: LF.sans, serif: LF.serif, mono: LF.mono,
+    titleSerif: false, titleWeight: 600, titleLetter: "-0.02em", radius: 8,
+    bubbleMe: L.bubbleMe, bubbleThem: L.bubbleThem,
+    chipActive: L.ink, chipActiveFg: L.bg, chipFg: L.ink2,
+  };
+  return window.SharedScreens.render({
+    screen, tokens,
+    Sidebar: () => <Linen_Sidebar active={screen}/>,
+    Chrome: Linen_Chrome,
+    backupComponent: Linen_Backup, messagesComponent: Linen_Messages,
+  });
+};

--- a/mockups/app/app-mockups/macos-window.jsx
+++ b/mockups/app/app-mockups/macos-window.jsx
@@ -1,0 +1,187 @@
+
+// MacOS.jsx — Simplified macOS Tahoe (Liquid Glass) window
+// Based on the macOS Tahoe UI Kit. No image assets, no dependencies.
+// Exports: MacWindow, MacSidebar, MacSidebarItem, MacToolbar, MacGlass, MacTrafficLights
+
+const MAC_FONT = '-apple-system, BlinkMacSystemFont, "SF Pro", "Helvetica Neue", sans-serif';
+
+// ─────────────────────────────────────────────────────────────
+// Liquid glass primitive — blur + white tint + inset highlight
+// ─────────────────────────────────────────────────────────────
+function MacGlass({ children, radius = 296, dark = false, style = {} }) {
+  return (
+    <div style={{ position: 'relative', borderRadius: radius, ...style }}>
+      <div style={{
+        position: 'absolute', inset: 0, borderRadius: radius,
+        background: dark ? 'rgba(255,255,255,0.08)' : 'rgba(255,255,255,0.35)',
+        backdropFilter: 'blur(40px) saturate(180%)',
+        WebkitBackdropFilter: 'blur(40px) saturate(180%)',
+        border: dark ? '0.5px solid rgba(255,255,255,0.12)' : '0.5px solid rgba(255,255,255,0.6)',
+        boxShadow: dark
+          ? '0 8px 40px rgba(0,0,0,0.2)'
+          : '0 8px 40px rgba(0,0,0,0.08), inset 0 1px 0 rgba(255,255,255,0.4)',
+      }} />
+      <div style={{ position: 'relative', zIndex: 1 }}>{children}</div>
+    </div>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────
+// Traffic lights (14px, Tahoe colors)
+// ─────────────────────────────────────────────────────────────
+function MacTrafficLights({ style = {} }) {
+  const dot = (bg) => (
+    <div style={{
+      width: 14, height: 14, borderRadius: '50%', background: bg,
+      border: '0.5px solid rgba(0,0,0,0.1)',
+    }} />
+  );
+  return (
+    <div style={{ display: 'flex', gap: 9, alignItems: 'center', padding: 1, ...style }}>
+      {dot('#ff736a')}{dot('#febc2e')}{dot('#19c332')}
+    </div>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────
+// Toolbar — title + single glass pill icon
+// ─────────────────────────────────────────────────────────────
+function MacToolbar({ title = 'Folder' }) {
+  return (
+    <div style={{
+      display: 'flex', gap: 8, alignItems: 'center', padding: 8, flexShrink: 0,
+    }}>
+      {/* title */}
+      <div style={{
+        fontFamily: MAC_FONT, fontSize: 15, fontWeight: 700,
+        color: 'rgba(0,0,0,0.85)', whiteSpace: 'nowrap', paddingLeft: 8,
+      }}>{title}</div>
+      <div style={{ flex: 1 }} />
+      {/* single action */}
+      <MacGlass>
+        <div style={{
+          width: 36, height: 36, display: 'flex',
+          alignItems: 'center', justifyContent: 'center',
+        }}>
+          <div style={{ width: 14, height: 14, borderRadius: '50%', background: '#4c4c4c', opacity: 0.4 }} />
+        </div>
+      </MacGlass>
+      {/* search */}
+      <MacGlass>
+        <div style={{
+          width: 140, height: 36, display: 'flex', alignItems: 'center',
+          gap: 6, padding: '0 12px',
+        }}>
+          <svg width="13" height="13" viewBox="0 0 13 13" fill="none">
+            <circle cx="5.5" cy="5.5" r="4" stroke="#727272" strokeWidth="1.5"/>
+            <path d="M8.5 8.5l3 3" stroke="#727272" strokeWidth="1.5" strokeLinecap="round"/>
+          </svg>
+          <span style={{
+            fontFamily: MAC_FONT, fontSize: 13, fontWeight: 500, color: '#727272',
+          }}>Search</span>
+        </div>
+      </MacGlass>
+    </div>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────
+// Sidebar — frosted glass panel floating inside the window
+// ─────────────────────────────────────────────────────────────
+function MacSidebarItem({ label, selected = false }) {
+  return (
+    <div style={{
+      display: 'flex', alignItems: 'center', gap: 6,
+      height: 24, padding: '4px 10px 4px 6px', margin: '0 10px',
+      borderRadius: 8, position: 'relative',
+      fontFamily: MAC_FONT, fontSize: 11, fontWeight: 500,
+    }}>
+      {selected && (
+        <div style={{
+          position: 'absolute', inset: 0, borderRadius: 8,
+          background: 'rgba(0,0,0,0.11)', mixBlendMode: 'multiply',
+        }} />
+      )}
+      <div style={{
+        width: 14, height: 14, borderRadius: '50%',
+        background: selected ? '#007aff' : 'rgba(0,0,0,0.4)',
+        opacity: selected ? 1 : 0.5, flexShrink: 0, position: 'relative',
+      }} />
+      <span style={{ color: 'rgba(0,0,0,0.85)', position: 'relative' }}>{label}</span>
+    </div>
+  );
+}
+
+function MacSidebar({ children }) {
+  return (
+    <div style={{
+      width: 220, height: '100%', padding: 8, flexShrink: 0,
+      position: 'relative', display: 'flex', flexDirection: 'column',
+    }}>
+      {/* glass panel */}
+      <div style={{
+        position: 'absolute', inset: 8, borderRadius: 18,
+        background: 'rgba(210,225,245,0.45)',
+        backdropFilter: 'blur(50px) saturate(200%)',
+        WebkitBackdropFilter: 'blur(50px) saturate(200%)',
+        border: '0.5px solid rgba(255,255,255,0.5)',
+        boxShadow: '0 8px 40px rgba(0,0,0,0.10), inset 0 1px 0 rgba(255,255,255,0.35)',
+      }} />
+      {/* content */}
+      <div style={{
+        position: 'relative', zIndex: 1, padding: '10px 0',
+        display: 'flex', flexDirection: 'column', gap: 2,
+      }}>
+        {/* window controls + sidebar toggle */}
+        <div style={{
+          height: 32, display: 'flex', alignItems: 'center',
+          justifyContent: 'space-between', padding: '0 10px', marginBottom: 4,
+        }}>
+          <MacTrafficLights />
+        </div>
+        {children}
+      </div>
+    </div>
+  );
+}
+
+function MacSidebarHeader({ title }) {
+  return (
+    <div style={{
+      padding: '14px 18px 5px',
+      fontFamily: MAC_FONT, fontSize: 11, fontWeight: 700,
+      color: 'rgba(0,0,0,0.5)',
+    }}>{title}</div>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────
+// Window — r:26, big shadow, sidebar + toolbar + content
+// ─────────────────────────────────────────────────────────────
+function MacWindow({
+  width = 900, height = 600, title = 'Folder',
+  sidebar, children,
+}) {
+  return (
+    <div style={{
+      width, height, borderRadius: 26, overflow: 'hidden',
+      background: '#fff',
+      boxShadow: '0 0 0 1px rgba(0,0,0,0.23), 0 16px 48px rgba(0,0,0,0.35)',
+      display: 'flex', position: 'relative',
+      fontFamily: MAC_FONT,
+    }}>
+      <MacSidebar>{sidebar}</MacSidebar>
+      <div style={{ flex: 1, display: 'flex', flexDirection: 'column' }}>
+        <MacToolbar title={title} />
+        <div style={{ flex: 1, overflow: 'auto', padding: '4px 8px' }}>
+          {children}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+Object.assign(window, {
+  MacWindow, MacSidebar, MacSidebarItem, MacSidebarHeader,
+  MacToolbar, MacGlass, MacTrafficLights,
+});

--- a/mockups/app/app-mockups/porcelain.jsx
+++ b/mockups/app/app-mockups/porcelain.jsx
@@ -1,0 +1,426 @@
+// ======================================================================
+// PORCELAIN — Near-white, one strong accent (deep ultramarine).
+// Restrained, confident. Editorial-clean.
+// Novel UX: Voicemail with a cassette-tape tactile player (with spools).
+// ======================================================================
+
+const PC = {
+  bg:       "#fbfbfb",
+  surface:  "#ffffff",
+  sunk:     "#f3f3f3",
+  ink:      "#0e0e14",
+  ink2:     "#505058",
+  ink3:     "#8a8a90",
+  rule:     "#e9e9ec",
+  ruleStr:  "#d8d8dc",
+  accent:   "#2848c8",
+  accentW:  "#e3e7f8",
+  sans:     "'Inter', system-ui, sans-serif",
+  serif:    "'Instrument Serif', 'Newsreader', serif",
+  mono:     "'JetBrains Mono', monospace",
+  titleSerif: false,
+  titleWeight: 600,
+  titleLetter: "-0.025em",
+  radius:   6,
+  bubbleMe:  "#2848c8",
+  bubbleThem:"#f3f3f3",
+  chipActive: "#0e0e14",
+  chipActiveFg: "#ffffff",
+  chipFg: "#505058",
+};
+
+const PorcelainChrome = ({ children }) => (
+  <div style={{
+    background: PC.bg, color: PC.ink, height: "100%",
+    fontFamily: PC.sans, display: "flex", flexDirection: "column",
+  }}>
+    <div style={{
+      height: 42, display: "flex", alignItems: "center", padding: "0 16px",
+      background: PC.bg, borderBottom: `1px solid ${PC.rule}`, flexShrink: 0,
+    }}>
+      <div className="tl"><span className="r"/><span className="y"/><span className="g"/></div>
+      <div style={{ marginLeft: 16, fontSize: 13, fontWeight: 600, letterSpacing: "-0.015em" }}>OpenExtract</div>
+      <span style={{ width: 3, height: 3, borderRadius: 99, background: PC.ink3, margin: "0 10px" }}/>
+      <span style={{ fontSize: 12, color: PC.ink2 }}>iPhone 13 Pro · Mom</span>
+      <div style={{ flex: 1 }}/>
+      <span style={{ fontSize: 10.5, color: PC.ink3, fontFamily: PC.mono, letterSpacing: "0.08em" }}>
+        ⎯ offline, always
+      </span>
+    </div>
+    {children}
+  </div>
+);
+
+const PorcelainSidebar = ({ active }) => {
+  const Icons = window.OEIcons;
+  const items = [
+    { id: "timeline",  label: "Timeline",  I: Icons.Clock },
+    { id: "messages",  label: "Messages",  I: Icons.Message },
+    { id: "photos",    label: "Photos",    I: Icons.Image },
+    { id: "voicemail", label: "Voicemail", I: Icons.Voicemail },
+    { id: "calls",     label: "Calls",     I: Icons.Phone },
+    { id: "contacts",  label: "Contacts",  I: Icons.User },
+    { id: "notes",     label: "Notes",     I: Icons.FileText },
+  ];
+  return (
+    <nav style={{
+      width: 204, flexShrink: 0, padding: "16px 10px",
+      borderRight: `1px solid ${PC.rule}`, background: PC.bg,
+      display: "flex", flexDirection: "column",
+    }}>
+      <div style={{ fontSize: 10.5, color: PC.ink3, letterSpacing: "0.12em",
+                    textTransform: "uppercase", padding: "4px 10px 10px", fontWeight: 600 }}>Library</div>
+      {items.map(it => {
+        const on = it.id === active;
+        const I = it.I;
+        return (
+          <div key={it.id} style={{
+            display: "flex", alignItems: "center", gap: 10,
+            padding: "7px 10px", borderRadius: 6, cursor: "pointer",
+            color: on ? PC.ink : PC.ink2,
+            background: on ? PC.accentW : "transparent",
+            borderLeft: on ? `2px solid ${PC.accent}` : "2px solid transparent",
+            marginLeft: on ? 0 : 2, marginBottom: 1,
+          }}>
+            <I size={14} strokeWidth={1.6} stroke={on ? PC.accent : PC.ink2}/>
+            <span style={{ fontSize: 13, fontWeight: on ? 600 : 400, letterSpacing: "-0.005em" }}>{it.label}</span>
+          </div>
+        );
+      })}
+    </nav>
+  );
+};
+
+const PorcelainBackup = () => {
+  const backups = window.OE_DATA.backups;
+  const Icons = window.OEIcons;
+  return (
+    <div style={{ flex: 1, overflow: "auto", background: PC.bg }}>
+      <div style={{ padding: "64px 72px 22px", maxWidth: 900 }}>
+        <div style={{ fontSize: 11, color: PC.accent, letterSpacing: "0.12em",
+                      textTransform: "uppercase", fontWeight: 600 }}>OpenExtract</div>
+        <h1 style={{
+          margin: "16px 0 12px", fontSize: 56, fontWeight: 600,
+          letterSpacing: "-0.03em", lineHeight: 1.02,
+        }}>
+          Three backups.<br/>
+          <span style={{ color: PC.ink3 }}>One is most recent.</span>
+        </h1>
+        <p style={{ margin: "6px 0 0", fontSize: 15, color: PC.ink2, lineHeight: 1.6, maxWidth: 560 }}>
+          Choose a backup. Everything is processed locally; no account, no upload.
+        </p>
+      </div>
+
+      <div style={{ padding: "0 72px 72px" }}>
+        {backups.map((b, i) => (
+          <div key={b.id} style={{
+            display: "grid", gridTemplateColumns: "60px 1.4fr 1fr 1fr 140px",
+            alignItems: "center", gap: 18, padding: "22px 0",
+            borderBottom: `1px solid ${PC.rule}`,
+          }}>
+            <div style={{
+              fontSize: 40, fontWeight: 600, color: i === 0 ? PC.accent : PC.ink3,
+              letterSpacing: "-0.02em", fontFamily: PC.sans,
+            }}>0{i+1}</div>
+            <div>
+              <div style={{ fontSize: 19, fontWeight: 600, letterSpacing: "-0.015em" }}>{b.device}</div>
+              <div style={{ fontSize: 13, color: PC.ink2, marginTop: 2 }}>{b.owner} · {b.ios}</div>
+            </div>
+            <div style={{ fontSize: 12.5, color: PC.ink2, lineHeight: 1.6, fontFamily: PC.mono }}>
+              {b.years[0]}—{b.years[b.years.length-1]}<br/>
+              <span style={{ color: PC.ink3 }}>last {b.lastBackup}</span>
+            </div>
+            <div style={{ fontSize: 12.5, color: PC.ink2, lineHeight: 1.6 }}>
+              <span style={{ color: PC.ink, fontFamily: PC.mono }}>{b.messages.toLocaleString()}</span> msgs ·
+              <span style={{ color: PC.ink, fontFamily: PC.mono }}> {b.photos.toLocaleString()}</span> photos<br/>
+              <span style={{ color: PC.ink, fontFamily: PC.mono }}>{b.calls.toLocaleString()}</span> calls ·
+              <span style={{ color: PC.ink, fontFamily: PC.mono }}> {b.voicemails}</span> vm
+            </div>
+            <div style={{ display: "flex", justifyContent: "flex-end" }}>
+              <button style={{
+                background: i === 0 ? PC.accent : PC.ink,
+                color: "#fff", border: 0,
+                padding: "10px 18px", borderRadius: 6,
+                fontSize: 13, fontWeight: 500,
+                display: "inline-flex", gap: 6, alignItems: "center",
+              }}>
+                Open <Icons.ArrowRight size={12} strokeWidth={2}/>
+              </button>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+const PorcelainMessages = () => {
+  const { conversations, activeThread } = window.OE_DATA;
+  const Icons = window.OEIcons;
+
+  return (
+    <div style={{ flex: 1, display: "flex", background: PC.bg, minWidth: 0 }}>
+      <aside style={{
+        width: 280, flexShrink: 0, borderRight: `1px solid ${PC.rule}`,
+        display: "flex", flexDirection: "column",
+      }}>
+        <div style={{ padding: "16px 16px 10px" }}>
+          <h2 style={{ margin: 0, fontSize: 17, fontWeight: 600, letterSpacing: "-0.015em" }}>Messages</h2>
+          <div style={{ fontSize: 11.5, color: PC.ink3, marginTop: 2, fontFamily: PC.mono }}>214 threads · 48,213 total</div>
+        </div>
+        <div style={{ overflow: "auto", flex: 1, padding: "4px 8px 12px" }}>
+          {conversations.map(c => {
+            const on = c.id === activeThread.contactId;
+            return (
+              <div key={c.id} style={{
+                display: "flex", gap: 10, padding: "9px 10px",
+                borderRadius: 6, cursor: "pointer",
+                background: on ? PC.accentW : "transparent",
+                borderLeft: on ? `2px solid ${PC.accent}` : "2px solid transparent",
+                marginLeft: on ? 0 : 2, marginBottom: 1,
+              }}>
+                <div style={{
+                  width: 30, height: 30, borderRadius: "50%", flexShrink: 0,
+                  background: `oklch(88% 0.04 ${c.avatarHue})`,
+                  border: `1px solid ${PC.rule}`,
+                  display: "flex", alignItems: "center", justifyContent: "center",
+                  fontSize: 12, color: PC.ink, fontWeight: 500,
+                }}>{c.name[0]}</div>
+                <div style={{ flex: 1, minWidth: 0 }}>
+                  <div style={{ display: "flex", justifyContent: "space-between", alignItems: "baseline" }}>
+                    <span style={{ fontSize: 13, color: PC.ink, fontWeight: on ? 600 : 500 }}>{c.name}</span>
+                    <span style={{ fontSize: 10, color: PC.ink3, fontFamily: PC.mono }}>{c.time}</span>
+                  </div>
+                  <div style={{
+                    fontSize: 11.5, color: PC.ink2, marginTop: 2,
+                    whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis",
+                  }}>{c.preview}</div>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      </aside>
+
+      <section style={{ flex: 1, display: "flex", flexDirection: "column", minWidth: 0 }}>
+        <div style={{
+          padding: "14px 26px", borderBottom: `1px solid ${PC.rule}`,
+          display: "flex", alignItems: "center", gap: 12,
+        }}>
+          <div style={{
+            width: 34, height: 34, borderRadius: "50%",
+            background: "oklch(88% 0.04 14)", border: `1px solid ${PC.rule}`,
+            display: "flex", alignItems: "center", justifyContent: "center",
+            fontSize: 13, fontWeight: 600,
+          }}>E</div>
+          <div style={{ flex: 1 }}>
+            <div style={{ fontSize: 15, fontWeight: 600, letterSpacing: "-0.01em" }}>Emma</div>
+            <div style={{ fontSize: 11.5, color: PC.ink3, marginTop: 1, fontFamily: PC.mono }}>847 msgs · 2016—2023</div>
+          </div>
+          <button style={{
+            background: PC.accent, color: "#fff", border: 0,
+            padding: "7px 14px", borderRadius: 6, fontSize: 12, fontWeight: 500,
+            display: "inline-flex", gap: 5, alignItems: "center",
+          }}>
+            <Icons.Export size={12} strokeWidth={1.8}/> Export
+          </button>
+        </div>
+
+        {/* scrubber: minimal dotted spine */}
+        <div style={{ padding: "14px 28px 10px", borderBottom: `1px solid ${PC.rule}` }}>
+          <div style={{ position: "relative", height: 26 }}>
+            <div style={{
+              position: "absolute", left: 0, right: 0, top: 12, height: 0,
+              borderTop: `1.5px dotted ${PC.ruleStr}`,
+            }}/>
+            {[2016,2017,2018,2019,2020,2021,2022,2023].map((y, i, arr) => {
+              const x = (i / (arr.length - 1)) * 100;
+              const active = y === 2023;
+              return (
+                <div key={y} style={{
+                  position: "absolute", left: `${x}%`, top: 0,
+                  transform: "translateX(-50%)", display: "flex", flexDirection: "column", alignItems: "center",
+                }}>
+                  <span style={{ fontSize: 10, color: active ? PC.accent : PC.ink3,
+                                  fontFamily: PC.mono, fontWeight: active ? 600 : 400 }}>{y}</span>
+                  <span style={{ marginTop: 2, width: active ? 10 : 4, height: active ? 10 : 4, borderRadius: 99,
+                                  background: active ? PC.accent : PC.ruleStr,
+                                  boxShadow: active ? `0 0 0 3px ${PC.accentW}` : "none" }}/>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+
+        <div style={{ flex: 1, overflow: "auto", padding: "22px 32px" }}>
+          <div style={{
+            textAlign: "center", fontSize: 11, color: PC.ink3, fontFamily: PC.mono,
+            letterSpacing: "0.1em", marginBottom: 16, textTransform: "uppercase",
+          }}>Aug 14, 2023 · 2:02 PM</div>
+          {activeThread.messages.map(m => {
+            const mine = m.from === "me";
+            return (
+              <div key={m.id} style={{
+                display: "flex", justifyContent: mine ? "flex-end" : "flex-start", marginBottom: 5,
+              }}>
+                <div style={{
+                  maxWidth: "62%",
+                  background: mine ? PC.bubbleMe : PC.bubbleThem,
+                  color: mine ? "#fff" : PC.ink,
+                  padding: m.kind === "photo" ? 4 : "9px 13px",
+                  borderRadius: 12,
+                  fontSize: 13.5, lineHeight: 1.42,
+                }}>
+                  {m.kind === "photo" ? (
+                    <div style={{
+                      width: 220, height: 160, borderRadius: 8, overflow: "hidden",
+                      background: "linear-gradient(135deg, oklch(72% 0.1 45), oklch(50% 0.14 25))",
+                      position: "relative",
+                    }}>
+                      <div style={{ position: "absolute", left: 8, bottom: 6, right: 8,
+                                     fontSize: 10, color: "#fff", fontFamily: PC.mono }}>{m.caption}</div>
+                    </div>
+                  ) : m.text}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      </section>
+    </div>
+  );
+};
+
+// --- Novel VOICEMAIL: cassette-tape player ---
+const PorcelainVoicemailNovel = ({ active, tokens: T }) => {
+  const Icons = window.OEIcons;
+  return (
+    <div style={{ flex: 1, padding: "32px 36px", overflow: "auto" }}>
+      {/* cassette body */}
+      <div style={{
+        background: "#1a1a1e", borderRadius: 14,
+        padding: "22px 26px 24px", position: "relative",
+        boxShadow: "0 30px 60px rgba(0,0,0,.18), inset 0 0 0 1px rgba(255,255,255,.06)",
+        maxWidth: 720,
+      }}>
+        {/* top label area */}
+        <div style={{
+          background: "#f7f3e9", borderRadius: 6, padding: "14px 16px 16px",
+          border: "1px solid #d8d0b8", marginBottom: 18, position: "relative",
+        }}>
+          <div style={{ fontSize: 10, color: "#7a6f50", letterSpacing: "0.14em",
+                         textTransform: "uppercase", fontWeight: 700, fontFamily: T.mono }}>
+            voicemail · side A
+          </div>
+          <div style={{
+            fontFamily: T.serif, fontSize: 22, color: "#222", marginTop: 4,
+            letterSpacing: "-0.01em",
+          }}>{active.from}</div>
+          <div style={{
+            fontFamily: T.mono, fontSize: 11, color: "#6a6a6a", marginTop: 2,
+          }}>{active.date} · {active.time} · {active.duration}</div>
+          <div style={{
+            position: "absolute", right: 14, top: 12,
+            fontFamily: T.mono, fontSize: 10, color: "#a89b7a", letterSpacing: "0.1em",
+          }}>C‑90</div>
+        </div>
+
+        {/* spools */}
+        <div style={{
+          display: "flex", alignItems: "center", justifyContent: "space-around",
+          padding: "0 4px", marginBottom: 16,
+        }}>
+          {[0, 1].map(s => (
+            <div key={s} style={{
+              width: 110, height: 110, borderRadius: "50%",
+              background: "radial-gradient(circle at 50% 50%, #2a2a30 0%, #141418 70%)",
+              border: "2px solid #3a3a42", position: "relative",
+              display: "flex", alignItems: "center", justifyContent: "center",
+            }}>
+              {/* spokes */}
+              {Array.from({ length: 6 }).map((_, i) => (
+                <div key={i} style={{
+                  position: "absolute", width: 4, height: 58,
+                  background: "#3a3a42", borderRadius: 2,
+                  transform: `rotate(${i * 30 + (s * 15)}deg)`,
+                  transformOrigin: "center",
+                }}/>
+              ))}
+              {/* hub */}
+              <div style={{
+                width: 28, height: 28, borderRadius: "50%",
+                background: T.accent, border: "2px solid #1a1a1e",
+                display: "flex", alignItems: "center", justifyContent: "center",
+              }}>
+                <div style={{ width: 8, height: 8, background: "#1a1a1e", borderRadius: 99 }}/>
+              </div>
+            </div>
+          ))}
+        </div>
+
+        {/* tape window */}
+        <div style={{
+          height: 14, background: "#6b5a3a", borderRadius: 3,
+          margin: "0 30px 18px", position: "relative",
+          boxShadow: "inset 0 2px 4px rgba(0,0,0,.5)",
+        }}>
+          <div style={{
+            position: "absolute", top: 0, bottom: 0, left: 0,
+            width: "62%", background: "#8b7a4a", borderRadius: 3,
+          }}/>
+        </div>
+
+        {/* transport */}
+        <div style={{
+          display: "flex", gap: 8, justifyContent: "center", alignItems: "center",
+        }}>
+          {["⏮", "⏸", "▶", "⏹", "⏭"].map((c, i) => (
+            <button key={i} style={{
+              width: i === 2 ? 54 : 40, height: 40,
+              borderRadius: 8, border: "1px solid #3a3a42",
+              background: i === 2 ? T.accent : "#2a2a30",
+              color: "#fff", fontSize: 14,
+              display: "flex", alignItems: "center", justifyContent: "center",
+            }}>{c}</button>
+          ))}
+          <div style={{ flex: 1 }}/>
+          <div style={{ fontFamily: T.mono, fontSize: 11, color: "#bbb" }}>0:14 / {active.duration}</div>
+        </div>
+      </div>
+
+      {/* transcript below */}
+      <div style={{
+        marginTop: 26, paddingTop: 20, borderTop: `1px solid ${T.rule}`, maxWidth: 680,
+      }}>
+        <div style={{ fontSize: 10.5, color: T.ink3, letterSpacing: "0.1em",
+                       textTransform: "uppercase", fontWeight: 600, marginBottom: 8 }}>Transcript</div>
+        <div style={{ fontFamily: T.serif, fontSize: 20, lineHeight: 1.55, color: T.ink, letterSpacing: "-0.005em" }}>
+          "{active.transcript}"
+        </div>
+      </div>
+    </div>
+  );
+};
+
+window.PorcelainRoot = ({ screen }) => {
+  const overrides = {
+    backup:   <PorcelainBackup/>,
+    messages: <PorcelainMessages/>,
+  };
+  const custom = overrides[screen];
+  if (custom) {
+    return (
+      <PorcelainChrome>
+        <div style={{ flex: 1, display: "flex", minHeight: 0 }}>
+          {screen !== "backup" && <PorcelainSidebar active={screen}/>}
+          {custom}
+        </div>
+      </PorcelainChrome>
+    );
+  }
+  return window.SharedScreens.render({
+    screen, tokens: PC, Sidebar: PorcelainSidebar, Chrome: PorcelainChrome,
+    backupComponent: PorcelainBackup, messagesComponent: PorcelainMessages,
+    novelVoicemail: (args) => <PorcelainVoicemailNovel {...args}/>,
+  });
+};

--- a/mockups/app/app-mockups/shared-screens.jsx
+++ b/mockups/app/app-mockups/shared-screens.jsx
@@ -1,0 +1,594 @@
+// Shared screen primitives — Timeline, Photos, Voicemail, Calls, Contacts, Notes.
+// Each variant supplies a `tokens` bundle describing its look, and a Sidebar
+// component. Backup + Messages stay variant-specific (that's where the novel
+// bits live).
+//
+// tokens: {
+//   bg, surface, sunk, ink, ink2, ink3, rule, ruleStr, accent, accentW,
+//   sans, serif, mono,
+//   titleSerif (bool), titleWeight (num), titleLetter (e.g. "-0.02em"),
+//   radius (num px), density: "compact"|"cozy",
+//   bubbleMe, bubbleThem,  // not used here but kept for symmetry
+//   chipActive (bg), chipActiveFg, chipFg,
+// }
+
+(function () {
+  const {
+    useState, useMemo, Fragment,
+  } = React;
+
+  const fmtNum = (n) => n.toLocaleString();
+
+  // ------- Common primitives -------
+  const HeaderBar = ({ tokens: T, title, sub, right }) => (
+    <div style={{
+      padding: "20px 28px 14px",
+      borderBottom: `1px solid ${T.rule}`,
+      display: "flex", alignItems: "flex-end", gap: 16,
+      background: T.bg, flexShrink: 0,
+    }}>
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <div style={{
+          fontSize: 11, color: T.ink3, letterSpacing: "0.06em",
+          textTransform: "uppercase", fontWeight: 500, marginBottom: 6,
+        }}>{sub}</div>
+        <h1 style={{
+          margin: 0,
+          fontFamily: T.titleSerif ? T.serif : T.sans,
+          fontWeight: T.titleWeight ?? (T.titleSerif ? 400 : 600),
+          fontSize: T.titleSerif ? 34 : 22,
+          letterSpacing: T.titleLetter ?? "-0.01em",
+          lineHeight: 1.05, color: T.ink,
+        }}>{title}</h1>
+      </div>
+      {right && <div style={{ display: "flex", gap: 8, alignItems: "center" }}>{right}</div>}
+    </div>
+  );
+
+  const Chip = ({ tokens: T, active, children }) => (
+    <button style={{
+      fontSize: 11.5, padding: "5px 10px", borderRadius: 99,
+      background: active ? (T.chipActive ?? T.ink) : "transparent",
+      color: active ? (T.chipActiveFg ?? T.bg) : (T.chipFg ?? T.ink2),
+      border: `1px solid ${active ? (T.chipActive ?? T.ink) : T.rule}`,
+      fontFamily: T.sans, fontWeight: active ? 500 : 400,
+    }}>{children}</button>
+  );
+
+  const GhostBtn = ({ tokens: T, children, icon }) => (
+    <button style={{
+      background: "transparent", border: `1px solid ${T.rule}`,
+      padding: "6px 11px", borderRadius: T.radius ?? 6,
+      fontSize: 12, color: T.ink, fontFamily: T.sans,
+      display: "inline-flex", gap: 6, alignItems: "center",
+    }}>{icon}{children}</button>
+  );
+
+  const PrimaryBtn = ({ tokens: T, children, icon }) => (
+    <button style={{
+      background: T.accent, color: "#fff", border: 0,
+      padding: "6px 12px", borderRadius: T.radius ?? 6,
+      fontSize: 12, fontWeight: 500, fontFamily: T.sans,
+      display: "inline-flex", gap: 6, alignItems: "center",
+    }}>{icon}{children}</button>
+  );
+
+  // ---------------- TIMELINE ----------------
+  const Timeline = ({ tokens: T }) => {
+    const Icons = window.OEIcons;
+    const events = window.OE_DATA.timeline;
+
+    const iconFor = (type) => ({
+      photo: Icons.Image, message: Icons.Message, call: Icons.Phone,
+      voicemail: Icons.Voicemail, note: Icons.FileText,
+    }[type]);
+
+    // Group by date
+    const byDate = [];
+    events.forEach(e => {
+      const last = byDate[byDate.length - 1];
+      if (last && last.date === e.date) last.items.push(e);
+      else byDate.push({ date: e.date, items: [e] });
+    });
+
+    return (
+      <div style={{ flex: 1, display: "flex", flexDirection: "column", background: T.bg, minWidth: 0 }}>
+        <HeaderBar tokens={T}
+          sub="Timeline · 65,396 events"
+          title="Everything, in order."
+          right={<>
+            <GhostBtn tokens={T} icon={<Icons.Filter size={12} strokeWidth={1.6}/>}>All types</GhostBtn>
+            <GhostBtn tokens={T} icon={<Icons.Search size={12} strokeWidth={1.6}/>}>Search</GhostBtn>
+            <PrimaryBtn tokens={T} icon={<Icons.Export size={12} strokeWidth={1.8}/>}>Export</PrimaryBtn>
+          </>}
+        />
+        <div style={{ flex: 1, overflow: "auto", padding: "20px 28px 32px" }}>
+          {byDate.map((grp, gi) => (
+            <div key={gi} style={{ marginBottom: 22 }}>
+              <div style={{
+                display: "flex", alignItems: "center", gap: 12, marginBottom: 10,
+              }}>
+                <div style={{
+                  fontSize: 12, color: T.ink2, fontFamily: T.mono, letterSpacing: "0.04em",
+                }}>{grp.date}</div>
+                <div style={{ flex: 1, height: 1, background: T.rule }}/>
+                <div style={{
+                  fontSize: 10.5, color: T.ink3, fontFamily: T.mono,
+                }}>{grp.items.length} {grp.items.length === 1 ? "event" : "events"}</div>
+              </div>
+              <div style={{
+                background: T.surface, border: `1px solid ${T.rule}`,
+                borderRadius: T.radius ?? 8, overflow: "hidden",
+              }}>
+                {grp.items.map((e, i) => {
+                  const I = iconFor(e.type);
+                  return (
+                    <div key={i} style={{
+                      display: "grid", gridTemplateColumns: "44px 60px 1fr auto",
+                      alignItems: "center", gap: 14, padding: "12px 16px",
+                      borderBottom: i === grp.items.length - 1 ? "none" : `1px solid ${T.rule}`,
+                    }}>
+                      <div style={{
+                        width: 30, height: 30, borderRadius: 8,
+                        background: `oklch(94% 0.03 ${e.hue})`,
+                        border: `1px solid ${T.rule}`,
+                        display: "flex", alignItems: "center", justifyContent: "center",
+                        color: `oklch(45% 0.12 ${e.hue})`,
+                      }}>
+                        <I size={14} strokeWidth={1.7}/>
+                      </div>
+                      <div style={{ fontSize: 11.5, color: T.ink3, fontFamily: T.mono }}>{e.time}</div>
+                      <div style={{ minWidth: 0 }}>
+                        <div style={{ fontSize: 13.5, color: T.ink, fontWeight: 500, letterSpacing: "-0.005em" }}>{e.title}</div>
+                        <div style={{ fontSize: 12, color: T.ink2, marginTop: 1, whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }}>{e.meta}</div>
+                      </div>
+                      <div style={{
+                        fontSize: 10.5, color: T.ink3, fontFamily: T.mono,
+                        textTransform: "uppercase", letterSpacing: "0.06em",
+                      }}>{e.type}</div>
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    );
+  };
+
+  // ---------------- PHOTOS ----------------
+  const Photos = ({ tokens: T }) => {
+    const Icons = window.OEIcons;
+    const photos = window.OE_DATA.photos;
+
+    const Tile = ({ p, big }) => (
+      <div style={{
+        gridColumn: big ? "span 2" : "span 1",
+        gridRow:    big ? "span 2" : "span 1",
+        borderRadius: T.radius ?? 8,
+        overflow: "hidden",
+        border: `1px solid ${T.rule}`,
+        background: `
+          linear-gradient(135deg, oklch(80% 0.08 ${p.hue}) 0%, oklch(62% 0.14 ${p.hue}) 100%),
+          repeating-linear-gradient(45deg, rgba(255,255,255,.08) 0 14px, rgba(0,0,0,.06) 14px 28px)
+        `,
+        backgroundBlendMode: "overlay",
+        position: "relative", minHeight: big ? 280 : 140,
+      }}>
+        <div style={{
+          position: "absolute", inset: 0,
+          background: "linear-gradient(180deg, rgba(0,0,0,0) 55%, rgba(0,0,0,.55) 100%)",
+        }}/>
+        <div style={{
+          position: "absolute", left: 10, bottom: 8, right: 10,
+          color: "#fff", fontFamily: T.sans,
+        }}>
+          <div style={{ fontSize: big ? 15 : 12.5, fontWeight: 500, letterSpacing: "-0.005em" }}>{p.album}</div>
+          <div style={{ fontSize: big ? 11 : 10, opacity: 0.85, marginTop: 2, fontFamily: T.mono, letterSpacing: "0.04em" }}>
+            {p.date} · {p.count} photos
+          </div>
+        </div>
+      </div>
+    );
+
+    return (
+      <div style={{ flex: 1, display: "flex", flexDirection: "column", background: T.bg, minWidth: 0 }}>
+        <HeaderBar tokens={T}
+          sub="Photos · 12,847 recovered"
+          title="Albums across seven years."
+          right={<>
+            <div style={{ display: "flex", gap: 6, marginRight: 8 }}>
+              <Chip tokens={T} active>Albums</Chip>
+              <Chip tokens={T}>All photos</Chip>
+              <Chip tokens={T}>Videos</Chip>
+              <Chip tokens={T}>Screenshots</Chip>
+            </div>
+            <PrimaryBtn tokens={T} icon={<Icons.Export size={12} strokeWidth={1.8}/>}>Export</PrimaryBtn>
+          </>}
+        />
+        <div style={{ flex: 1, overflow: "auto", padding: "22px 28px 32px" }}>
+          <div style={{
+            display: "grid", gridTemplateColumns: "repeat(4, 1fr)",
+            gridAutoRows: 140, gap: 12,
+          }}>
+            {photos.map(p => <Tile key={p.id} p={p} big={p.big}/>)}
+          </div>
+        </div>
+      </div>
+    );
+  };
+
+  // ---------------- VOICEMAIL ----------------
+  const Voicemail = ({ tokens: T, novelRenderer }) => {
+    const Icons = window.OEIcons;
+    const vms = window.OE_DATA.voicemails;
+    const [activeId, setActiveId] = useState(vms[0].id);
+    const active = vms.find(v => v.id === activeId) ?? vms[0];
+
+    return (
+      <div style={{ flex: 1, display: "flex", background: T.bg, minWidth: 0 }}>
+        {/* list */}
+        <aside style={{
+          width: 340, flexShrink: 0, borderRight: `1px solid ${T.rule}`,
+          display: "flex", flexDirection: "column", background: T.bg,
+        }}>
+          <div style={{ padding: "18px 18px 8px" }}>
+            <div style={{
+              fontSize: 11, color: T.ink3, letterSpacing: "0.06em",
+              textTransform: "uppercase", fontWeight: 500, marginBottom: 6,
+            }}>Voicemails · {vms.length}</div>
+            <h2 style={{
+              margin: 0, fontFamily: T.titleSerif ? T.serif : T.sans,
+              fontWeight: T.titleWeight ?? (T.titleSerif ? 400 : 600),
+              fontSize: T.titleSerif ? 24 : 18,
+              letterSpacing: T.titleLetter ?? "-0.01em",
+            }}>Voicemail</h2>
+          </div>
+          <div style={{ flex: 1, overflow: "auto", padding: "4px 8px 12px" }}>
+            {vms.map(v => {
+              const on = v.id === activeId;
+              return (
+                <div key={v.id} onClick={() => setActiveId(v.id)} style={{
+                  padding: "10px 12px", borderRadius: T.radius ?? 6,
+                  cursor: "pointer",
+                  background: on ? T.accentW : "transparent",
+                  borderLeft: on ? `2px solid ${T.accent}` : "2px solid transparent",
+                  marginLeft: on ? 0 : 2, marginBottom: 2,
+                }}>
+                  <div style={{ display: "flex", justifyContent: "space-between", alignItems: "baseline", marginBottom: 3 }}>
+                    <span style={{ fontSize: 13, color: T.ink, fontWeight: on ? 600 : 500, letterSpacing: "-0.005em" }}>{v.from}</span>
+                    <span style={{ fontSize: 10.5, color: T.ink3, fontFamily: T.mono }}>{v.duration}</span>
+                  </div>
+                  <div style={{ fontSize: 11.5, color: T.ink3, fontFamily: T.mono, marginBottom: 4 }}>{v.date} · {v.time}</div>
+                  <div style={{
+                    fontSize: 12, color: T.ink2, lineHeight: 1.4,
+                    display: "-webkit-box", WebkitLineClamp: 2, WebkitBoxOrient: "vertical",
+                    overflow: "hidden",
+                  }}>{v.transcript}</div>
+                </div>
+              );
+            })}
+          </div>
+        </aside>
+        {/* detail */}
+        <section style={{ flex: 1, display: "flex", flexDirection: "column", minWidth: 0 }}>
+          <div style={{
+            padding: "18px 28px", borderBottom: `1px solid ${T.rule}`,
+            display: "flex", alignItems: "center", gap: 14,
+          }}>
+            <div style={{
+              width: 42, height: 42, borderRadius: "50%",
+              background: `oklch(88% 0.05 ${200})`, border: `1px solid ${T.rule}`,
+              display: "flex", alignItems: "center", justifyContent: "center",
+              color: T.ink, fontWeight: 500,
+            }}>{active.from[0]}</div>
+            <div style={{ flex: 1 }}>
+              <div style={{ fontSize: 15, fontWeight: 600, letterSpacing: "-0.005em" }}>{active.from}</div>
+              <div style={{ fontSize: 11.5, color: T.ink3, fontFamily: T.mono, marginTop: 2 }}>
+                {active.date} · {active.time} · {active.duration}
+              </div>
+            </div>
+            <GhostBtn tokens={T} icon={<Icons.Download size={12} strokeWidth={1.7}/>}>Export audio</GhostBtn>
+          </div>
+
+          {/* novel area — fall back to a waveform + transcript */}
+          {novelRenderer ? novelRenderer({ active, tokens: T }) : (
+            <div style={{ flex: 1, padding: "28px 28px", overflow: "auto" }}>
+              <div style={{
+                background: T.surface, border: `1px solid ${T.rule}`,
+                borderRadius: T.radius ?? 10, padding: "18px 20px", marginBottom: 18,
+              }}>
+                <svg viewBox="0 0 600 80" width="100%" height="70" preserveAspectRatio="none">
+                  {Array.from({ length: 120 }).map((_, i) => {
+                    const h = 6 + Math.abs(Math.sin(i * 0.35 + i * 0.08)) * 40 + (i % 7 === 0 ? 14 : 0);
+                    return <rect key={i} x={i * 5} y={40 - h/2} width={2.6} height={h}
+                                 fill={i < 36 ? T.accent : T.ink3} rx={1} opacity={i < 36 ? 1 : 0.5}/>;
+                  })}
+                </svg>
+                <div style={{ display: "flex", alignItems: "center", gap: 12, marginTop: 6 }}>
+                  <button style={{
+                    width: 34, height: 34, borderRadius: 99, border: 0,
+                    background: T.accent, color: "#fff",
+                    display: "flex", alignItems: "center", justifyContent: "center",
+                  }}>
+                    <svg width="12" height="12" viewBox="0 0 24 24" fill="currentColor"><path d="M6 4l14 8-14 8z"/></svg>
+                  </button>
+                  <div style={{ fontFamily: T.mono, fontSize: 11, color: T.ink2 }}>0:14 / {active.duration}</div>
+                  <div style={{ flex: 1 }}/>
+                  <div style={{ fontFamily: T.mono, fontSize: 11, color: T.ink3 }}>1.0×</div>
+                </div>
+              </div>
+              <div style={{
+                fontSize: 11, color: T.ink3, letterSpacing: "0.06em",
+                textTransform: "uppercase", fontWeight: 500, marginBottom: 8,
+              }}>Transcript · auto-generated</div>
+              <div style={{
+                fontFamily: T.serif ?? T.sans, fontSize: 16, lineHeight: 1.65, color: T.ink,
+                maxWidth: 640,
+              }}>
+                “{active.transcript}”
+              </div>
+            </div>
+          )}
+        </section>
+      </div>
+    );
+  };
+
+  // ---------------- CALLS ----------------
+  const Calls = ({ tokens: T }) => {
+    const Icons = window.OEIcons;
+    const calls = window.OE_DATA.calls;
+    const dirIcon = (d) => {
+      if (d === "in")     return { char: "↙", color: "oklch(48% 0.14 150)" };
+      if (d === "out")    return { char: "↗", color: "oklch(50% 0.14 220)" };
+      return                     { char: "×", color: "oklch(55% 0.16 25)" };
+    };
+
+    return (
+      <div style={{ flex: 1, display: "flex", flexDirection: "column", background: T.bg, minWidth: 0 }}>
+        <HeaderBar tokens={T}
+          sub="Calls · 4,281 records"
+          title="Every call, inbound and out."
+          right={<>
+            <div style={{ display: "flex", gap: 6, marginRight: 8 }}>
+              <Chip tokens={T} active>All</Chip>
+              <Chip tokens={T}>Missed</Chip>
+              <Chip tokens={T}>FaceTime</Chip>
+            </div>
+            <PrimaryBtn tokens={T} icon={<Icons.Export size={12} strokeWidth={1.8}/>}>Export CSV</PrimaryBtn>
+          </>}
+        />
+        <div style={{ flex: 1, overflow: "auto", padding: "22px 28px 32px" }}>
+          <div style={{
+            background: T.surface, border: `1px solid ${T.rule}`, borderRadius: T.radius ?? 10,
+            overflow: "hidden",
+          }}>
+            <div style={{
+              display: "grid",
+              gridTemplateColumns: "40px 1.4fr 1.4fr 0.8fr 0.7fr",
+              padding: "11px 18px", background: T.sunk,
+              borderBottom: `1px solid ${T.rule}`,
+              fontSize: 10.5, color: T.ink3, letterSpacing: "0.06em",
+              textTransform: "uppercase", fontWeight: 500,
+            }}>
+              <div></div><div>Contact</div><div>When</div><div>Duration</div><div>Service</div>
+            </div>
+            {calls.map((c, i) => {
+              const d = dirIcon(c.dir);
+              return (
+                <div key={i} style={{
+                  display: "grid",
+                  gridTemplateColumns: "40px 1.4fr 1.4fr 0.8fr 0.7fr",
+                  padding: "12px 18px", alignItems: "center",
+                  borderBottom: i === calls.length - 1 ? "none" : `1px solid ${T.rule}`,
+                  fontSize: 13, color: T.ink,
+                }}>
+                  <div style={{ color: d.color, fontSize: 15, fontWeight: 600 }}>{d.char}</div>
+                  <div style={{ fontWeight: 500, letterSpacing: "-0.005em" }}>{c.who}</div>
+                  <div style={{ color: T.ink2, fontFamily: T.mono, fontSize: 12 }}>{c.date}</div>
+                  <div style={{ fontFamily: T.mono, fontSize: 12 }}>{c.dur}</div>
+                  <div style={{ color: T.ink2, fontSize: 12 }}>{c.svc}</div>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      </div>
+    );
+  };
+
+  // ---------------- CONTACTS ----------------
+  const Contacts = ({ tokens: T, novelRenderer }) => {
+    const Icons = window.OEIcons;
+    const contacts = window.OE_DATA.contacts;
+
+    if (novelRenderer) {
+      return (
+        <div style={{ flex: 1, display: "flex", flexDirection: "column", background: T.bg, minWidth: 0 }}>
+          <HeaderBar tokens={T}
+            sub="Contacts · 612 total"
+            title="People, by how often she called."
+          />
+          {novelRenderer({ contacts, tokens: T })}
+        </div>
+      );
+    }
+
+    return (
+      <div style={{ flex: 1, display: "flex", flexDirection: "column", background: T.bg, minWidth: 0 }}>
+        <HeaderBar tokens={T}
+          sub="Contacts · 612 total"
+          title="The people who mattered."
+          right={<>
+            <GhostBtn tokens={T} icon={<Icons.Search size={12} strokeWidth={1.6}/>}>Search</GhostBtn>
+            <PrimaryBtn tokens={T} icon={<Icons.Export size={12} strokeWidth={1.8}/>}>Export vCard</PrimaryBtn>
+          </>}
+        />
+        <div style={{ flex: 1, overflow: "auto", padding: "22px 28px 32px" }}>
+          <div style={{
+            display: "grid", gridTemplateColumns: "repeat(3, 1fr)", gap: 12,
+          }}>
+            {contacts.map((c, i) => (
+              <div key={i} style={{
+                background: T.surface, border: `1px solid ${T.rule}`,
+                borderRadius: T.radius ?? 8, padding: "14px 16px",
+                display: "flex", gap: 12, alignItems: "center",
+              }}>
+                <div style={{
+                  width: 40, height: 40, borderRadius: "50%", flexShrink: 0,
+                  background: `oklch(88% 0.05 ${c.hue})`,
+                  border: `1px solid ${T.rule}`,
+                  display: "flex", alignItems: "center", justifyContent: "center",
+                  fontSize: 15, color: T.ink, fontWeight: 500, fontFamily: T.sans,
+                }}>{c.name[0]}</div>
+                <div style={{ flex: 1, minWidth: 0 }}>
+                  <div style={{ fontSize: 13.5, fontWeight: 500, letterSpacing: "-0.005em",
+                                whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }}>{c.name}</div>
+                  <div style={{ fontSize: 11.5, color: T.ink3 }}>{c.role}</div>
+                  <div style={{ fontSize: 11, color: T.ink3, fontFamily: T.mono, marginTop: 3 }}>
+                    {c.phone}
+                  </div>
+                </div>
+                <div style={{
+                  fontSize: 10.5, color: T.ink3, fontFamily: T.mono,
+                  textAlign: "right",
+                }}>
+                  <div style={{ fontWeight: 500, color: T.accent, fontSize: 12 }}>{c.freq}</div>
+                  <div>msgs</div>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    );
+  };
+
+  // ---------------- NOTES ----------------
+  const Notes = ({ tokens: T }) => {
+    const Icons = window.OEIcons;
+    const notes = window.OE_DATA.notes;
+    const [activeId, setActiveId] = useState(notes[0].id);
+    const active = notes.find(n => n.id === activeId) ?? notes[0];
+
+    const noteBody = {
+      n1: "Emma: medium, navy preferred. Something soft, nothing itchy.\n\nNora: 6X, avoid pink if possible. Loves dinosaurs right now.\n\nEthan: large. Asked for nothing. Get him a sweater anyway.\n\nTeddy (new baby): 3–6m, earth tones. Sarah said no white, no yellow — they stain.",
+      n2: "bread\npeaches (2 lb, ripe ones)\nvanilla bean\nolive oil — good kind\nthat cheese Dad likes (tell Noah at counter)\ncoffee filters\nstamps",
+      n3: "Mom's peach cobbler\n\n6 peaches, peeled and sliced\n1 cup flour\n1 cup sugar\n1 stick butter, melted in the pan\n1 cup milk\n1 tsp baking powder\npinch salt\ncinnamon + nutmeg\n\n350° for 45 min. Do NOT stir after pouring batter.",
+      n4: "Demon Copperhead — Marjorie rec, keeps mentioning it\nTom Lake — finally\nTrust (Hernan Diaz)\nNorth Woods — Dan bought me this, finish it\nBel Canto — reread?",
+      n5: "not storing any here anymore — use the little book",
+      n6: "23 letters, Dad to Mom, bundled with blue ribbon. Postmarks: Ann Arbor (Oct 1986 – May 1987), Boulder (Jun–Aug 1987), Charleston (Sep 1987 – Feb 1988). All Dad's handwriting. Need to photograph these before they fade any more.",
+      n7: "senior food, half scoop breakfast, half scoop dinner\nno table scraps per Dr. Okafor\nglucosamine chew every morning\nvet every 6 months now",
+    }[active.id] ?? active.preview;
+
+    return (
+      <div style={{ flex: 1, display: "flex", background: T.bg, minWidth: 0 }}>
+        <aside style={{
+          width: 320, flexShrink: 0, borderRight: `1px solid ${T.rule}`,
+          display: "flex", flexDirection: "column", background: T.bg,
+        }}>
+          <div style={{ padding: "18px 18px 10px" }}>
+            <div style={{
+              fontSize: 11, color: T.ink3, letterSpacing: "0.06em",
+              textTransform: "uppercase", fontWeight: 500, marginBottom: 6,
+            }}>Notes · {notes.length} recovered</div>
+            <h2 style={{
+              margin: 0, fontFamily: T.titleSerif ? T.serif : T.sans,
+              fontWeight: T.titleWeight ?? (T.titleSerif ? 400 : 600),
+              fontSize: T.titleSerif ? 24 : 18,
+              letterSpacing: T.titleLetter ?? "-0.01em",
+            }}>Notes</h2>
+          </div>
+          <div style={{ flex: 1, overflow: "auto", padding: "4px 8px 12px" }}>
+            {notes.map(n => {
+              const on = n.id === activeId;
+              return (
+                <div key={n.id} onClick={() => setActiveId(n.id)} style={{
+                  padding: "11px 12px", borderRadius: T.radius ?? 6, cursor: "pointer",
+                  background: on ? T.accentW : "transparent",
+                  borderLeft: on ? `2px solid ${T.accent}` : "2px solid transparent",
+                  marginLeft: on ? 0 : 2, marginBottom: 2,
+                }}>
+                  <div style={{ display: "flex", alignItems: "baseline", gap: 6 }}>
+                    {n.pinned && <span style={{ color: T.accent, fontSize: 10 }}>●</span>}
+                    <span style={{ fontSize: 13, color: T.ink, fontWeight: on ? 600 : 500, letterSpacing: "-0.005em",
+                                   flex: 1, whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }}>{n.title}</span>
+                    <span style={{ fontSize: 10.5, color: T.ink3, fontFamily: T.mono }}>{n.date.split(",")[0]}</span>
+                  </div>
+                  <div style={{
+                    fontSize: 12, color: T.ink2, lineHeight: 1.4, marginTop: 2,
+                    display: "-webkit-box", WebkitLineClamp: 2, WebkitBoxOrient: "vertical",
+                    overflow: "hidden",
+                  }}>{n.preview}</div>
+                </div>
+              );
+            })}
+          </div>
+        </aside>
+        <section style={{ flex: 1, display: "flex", flexDirection: "column", minWidth: 0 }}>
+          <div style={{
+            padding: "18px 32px", borderBottom: `1px solid ${T.rule}`,
+            display: "flex", alignItems: "center", gap: 12,
+          }}>
+            <div style={{ flex: 1 }}>
+              <div style={{ fontSize: 10.5, color: T.ink3, fontFamily: T.mono, letterSpacing: "0.06em", textTransform: "uppercase" }}>
+                {active.date}{active.pinned ? " · pinned" : ""}
+              </div>
+              <div style={{
+                fontSize: T.titleSerif ? 22 : 18, fontWeight: T.titleSerif ? 500 : 600,
+                fontFamily: T.titleSerif ? T.serif : T.sans, marginTop: 3, letterSpacing: "-0.01em",
+              }}>{active.title}</div>
+            </div>
+            <GhostBtn tokens={T} icon={<Icons.Export size={12} strokeWidth={1.7}/>}>Export</GhostBtn>
+          </div>
+          <div style={{ flex: 1, overflow: "auto", padding: "26px 38px 40px" }}>
+            <pre style={{
+              fontFamily: T.serif ?? T.sans, fontSize: 15.5, lineHeight: 1.7, color: T.ink,
+              margin: 0, whiteSpace: "pre-wrap", maxWidth: 680,
+            }}>{noteBody}</pre>
+          </div>
+        </section>
+      </div>
+    );
+  };
+
+  // -------------- Renderer --------------
+  // variant passes { screen, tokens, Sidebar, Chrome,
+  //   backupComponent, messagesComponent,
+  //   novelVoicemail?, novelContacts? }
+  const render = ({
+    screen, tokens, Sidebar, Chrome,
+    backupComponent: Backup,
+    messagesComponent: Messages,
+    novelVoicemail, novelContacts,
+  }) => {
+    let Body;
+    switch (screen) {
+      case "backup":    Body = <Backup/>; break;
+      case "messages":  Body = <Messages/>; break;
+      case "timeline":  Body = <Timeline tokens={tokens}/>; break;
+      case "photos":    Body = <Photos tokens={tokens}/>; break;
+      case "voicemail": Body = <Voicemail tokens={tokens} novelRenderer={novelVoicemail}/>; break;
+      case "calls":     Body = <Calls tokens={tokens}/>; break;
+      case "contacts":  Body = <Contacts tokens={tokens} novelRenderer={novelContacts}/>; break;
+      case "notes":     Body = <Notes tokens={tokens}/>; break;
+      default:          Body = <Backup/>;
+    }
+
+    // Chrome wraps everything; inside, sidebar + body sit side-by-side
+    // (backup screen is full-width — skip sidebar)
+    const showSidebar = screen !== "backup";
+    return (
+      <Chrome>
+        <div style={{ flex: 1, display: "flex", minHeight: 0 }}>
+          {showSidebar && <Sidebar active={screen}/>}
+          {Body}
+        </div>
+      </Chrome>
+    );
+  };
+
+  window.SharedScreens = { render, Timeline, Photos, Voicemail, Calls, Contacts, Notes, HeaderBar, Chip, GhostBtn, PrimaryBtn };
+})();

--- a/mockups/app/app-mockups/studio.jsx
+++ b/mockups/app/app-mockups/studio.jsx
@@ -1,0 +1,500 @@
+// ======================================================================
+// STUDIO — Editorial dark
+// Deep plum/ink #14101a with peach accent #f0a07a.
+// Oversized Fraunces display, Inter body.
+// Novel UX: messages view has a SCRUBBABLE YEAR STRIP at top — drag to jump.
+// Backup picker: editorial "cover" treatment with big type and issue numbers.
+// ======================================================================
+
+const S = {
+  bg:      "#14101a",
+  surface: "#1c1824",
+  raised:  "#251f2e",
+  over:    "#2f2939",
+  ink:     "#f4eee8",
+  ink2:    "#a79eb0",
+  ink3:    "#6c6579",
+  rule:    "#2a2432",
+  ruleSoft:"#221d2a",
+  accent:  "#f0a07a",  // peach
+  accent2: "#c58fd4",  // soft orchid for badges
+  bubbleMe: "#f0a07a",
+  bubbleThem: "#251f2e",
+};
+const SF = {
+  serif: "'Fraunces', 'Instrument Serif', serif",
+  sans:  "'Inter', system-ui, sans-serif",
+  mono:  "'JetBrains Mono', monospace",
+};
+
+const Studio_Chrome = ({ children }) => (
+  <div style={{
+    background: S.bg, color: S.ink, height: "100%",
+    fontFamily: SF.sans, display: "flex", flexDirection: "column",
+  }}>
+    <div style={{
+      height: 44, display: "flex", alignItems: "center", padding: "0 16px",
+      background: S.bg, borderBottom: `1px solid ${S.ruleSoft}`, flexShrink: 0,
+    }}>
+      <div className="tl"><span className="r"/><span className="y"/><span className="g"/></div>
+      <div style={{
+        marginLeft: 16, fontFamily: SF.serif, fontSize: 18, fontWeight: 500, letterSpacing: "-0.015em",
+      }}>
+        Open<span style={{ fontStyle: "italic", color: S.accent }}>Extract</span>
+      </div>
+      <div style={{ flex: 1 }}/>
+      <div style={{ fontFamily: SF.mono, fontSize: 10.5, color: S.ink3, letterSpacing: "0.14em", textTransform: "uppercase" }}>
+        ISSUE 03 · MOM'S PHONE
+      </div>
+    </div>
+    {children}
+  </div>
+);
+
+const Studio_Sidebar = ({ active }) => {
+  const Icons = window.OEIcons;
+  const items = [
+    { id: "timeline",  label: "Timeline",  n: "01" },
+    { id: "messages",  label: "Messages",  n: "02" },
+    { id: "photos",    label: "Photos",    n: "03" },
+    { id: "voicemail", label: "Voicemail", n: "04" },
+    { id: "calls",     label: "Calls",     n: "05" },
+    { id: "contacts",  label: "Contacts",  n: "06" },
+    { id: "notes",     label: "Notes",     n: "07" },
+  ];
+  const iconMap = { timeline: Icons.Clock, messages: Icons.Message, photos: Icons.Image,
+                    voicemail: Icons.Voicemail, calls: Icons.Phone, contacts: Icons.User, notes: Icons.FileText };
+  return (
+    <nav style={{
+      width: 210, flexShrink: 0, padding: "22px 16px",
+      borderRight: `1px solid ${S.ruleSoft}`,
+      background: S.bg,
+      display: "flex", flexDirection: "column",
+    }}>
+      <div style={{
+        fontFamily: SF.mono, fontSize: 10, letterSpacing: "0.18em",
+        color: S.ink3, textTransform: "uppercase", padding: "6px 4px 14px",
+      }}>Sections</div>
+      {items.map(it => {
+        const on = it.id === active;
+        const I = iconMap[it.id];
+        return (
+          <div key={it.id} style={{
+            display: "flex", alignItems: "center", gap: 10,
+            padding: "9px 10px", borderRadius: 8, cursor: "pointer",
+            color: on ? S.ink : S.ink2,
+            background: on ? S.surface : "transparent",
+          }}>
+            <span style={{ fontFamily: SF.mono, fontSize: 10, color: on ? S.accent : S.ink3, width: 18 }}>
+              {it.n}
+            </span>
+            <I size={15} strokeWidth={1.6} stroke={on ? S.accent : S.ink2}/>
+            <span style={{ fontSize: 13.5, fontWeight: on ? 500 : 400, letterSpacing: "-0.005em" }}>
+              {it.label}
+            </span>
+          </div>
+        );
+      })}
+      <div style={{ flex: 1 }}/>
+      <div style={{
+        padding: "12px 10px", borderTop: `1px solid ${S.ruleSoft}`,
+        fontSize: 11, color: S.ink3, lineHeight: 1.5,
+      }}>
+        <div style={{ color: S.ink2, fontWeight: 500, fontSize: 12 }}>Privacy</div>
+        Nothing sent anywhere. Source open on GitHub.
+      </div>
+    </nav>
+  );
+};
+
+// --- BACKUP: editorial cover ---
+const Studio_Backup = () => {
+  const backups = window.OE_DATA.backups;
+  const Icons = window.OEIcons;
+
+  return (
+    <div style={{ flex: 1, overflow: "auto", background: S.bg }}>
+      {/* Cover masthead */}
+      <div style={{
+        padding: "56px 56px 30px", position: "relative",
+        borderBottom: `1px solid ${S.ruleSoft}`,
+      }}>
+        <div style={{
+          display: "flex", justifyContent: "space-between", alignItems: "flex-end",
+          fontFamily: SF.mono, fontSize: 10.5, color: S.ink3, letterSpacing: "0.16em",
+          textTransform: "uppercase",
+        }}>
+          <span>Vol. 1 · Library</span>
+          <span>3 backups found · MobileSync</span>
+        </div>
+        <h1 style={{
+          margin: "18px 0 6px",
+          fontFamily: SF.serif, fontWeight: 400,
+          fontSize: 108, lineHeight: 0.92,
+          letterSpacing: "-0.035em",
+          maxWidth: 900,
+        }}>
+          Pick a <span style={{ fontStyle: "italic", color: S.accent }}>phone</span>,<br/>
+          open a <span style={{ fontStyle: "italic", color: S.accent2 }}>decade</span>.
+        </h1>
+        <p style={{ maxWidth: 620, fontSize: 15, color: S.ink2, lineHeight: 1.55, marginTop: 18 }}>
+          Every iTunes/Finder backup on this Mac, turned into something you can actually read. Choose one below — we'll open it locally, no accounts, no upload, no rush.
+        </p>
+      </div>
+
+      {/* Cards */}
+      <div style={{
+        padding: "30px 56px 56px",
+        display: "grid", gridTemplateColumns: "1.4fr 1fr 1fr", gap: 20,
+      }}>
+        {backups.map((b, i) => {
+          const featured = i === 0;
+          return (
+            <div key={b.id} style={{
+              background: featured ? S.surface : S.bg,
+              border: `1px solid ${featured ? S.rule : S.ruleSoft}`,
+              borderRadius: 14, padding: featured ? "28px" : "22px",
+              display: "flex", flexDirection: "column", gap: 14,
+              position: "relative", overflow: "hidden",
+            }}>
+              {featured && (
+                <div style={{
+                  position: "absolute", top: 0, right: 0, width: 220, height: 220,
+                  background: `radial-gradient(circle at 70% 30%, rgba(240,160,122,.22), transparent 60%)`,
+                  pointerEvents: "none",
+                }}/>
+              )}
+              <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", position: "relative" }}>
+                <div style={{ fontFamily: SF.mono, fontSize: 10, letterSpacing: "0.14em", color: S.ink3, textTransform: "uppercase" }}>
+                  № {String(i + 1).padStart(2, "0")}
+                </div>
+                <div style={{
+                  display: "inline-flex", alignItems: "center", gap: 6,
+                  padding: "4px 10px", borderRadius: 999,
+                  border: `1px solid ${b.encrypted ? "rgba(240,160,122,.35)" : S.rule}`,
+                  color: b.encrypted ? S.accent : S.ink2, fontSize: 10.5,
+                  fontFamily: SF.mono, letterSpacing: "0.06em", textTransform: "uppercase",
+                }}>
+                  <Icons.Lock size={10} strokeWidth={1.8}/>
+                  {b.encrypted ? "Encrypted" : "Open"}
+                </div>
+              </div>
+
+              <div style={{ position: "relative" }}>
+                <div style={{
+                  fontFamily: SF.serif, fontWeight: 400,
+                  fontSize: featured ? 56 : 34, lineHeight: 0.98,
+                  letterSpacing: "-0.025em",
+                }}>
+                  {b.device}
+                </div>
+                <div style={{
+                  marginTop: 6, fontSize: featured ? 15 : 13, color: S.ink2,
+                  fontStyle: "italic", fontFamily: SF.serif,
+                }}>
+                  “{b.owner}”
+                </div>
+              </div>
+
+              <div style={{
+                display: "flex", gap: 14, flexWrap: "wrap", marginTop: 2,
+                fontFamily: SF.mono, fontSize: 10.5, letterSpacing: "0.08em",
+                color: S.ink3, textTransform: "uppercase",
+              }}>
+                <span>{b.ios}</span>
+                <span>·</span>
+                <span>{b.lastBackup}</span>
+                <span>·</span>
+                <span>{b.size}</span>
+              </div>
+
+              {featured ? (
+                <div style={{
+                  marginTop: 8, display: "grid", gridTemplateColumns: "repeat(4,1fr)", gap: 10,
+                }}>
+                  {[["Messages", b.messages], ["Photos", b.photos], ["Calls", b.calls], ["Notes", b.notes]].map(([k, v]) => (
+                    <div key={k} style={{
+                      background: S.raised, border: `1px solid ${S.rule}`,
+                      borderRadius: 10, padding: "10px 12px",
+                    }}>
+                      <div style={{ fontFamily: SF.mono, fontSize: 9.5, color: S.ink3, letterSpacing: "0.12em", textTransform: "uppercase" }}>{k}</div>
+                      <div style={{ fontFamily: SF.serif, fontSize: 22, fontWeight: 500, color: S.ink, marginTop: 2 }}>
+                        {v.toLocaleString()}
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              ) : (
+                <div style={{ marginTop: 4, fontSize: 12.5, color: S.ink2, lineHeight: 1.55 }}>
+                  {b.messages.toLocaleString()} messages · {b.photos.toLocaleString()} photos · {b.voicemails} voicemails
+                </div>
+              )}
+
+              <div style={{ flex: 1 }}/>
+
+              <button style={{
+                marginTop: 8,
+                background: featured ? S.accent : "transparent",
+                color: featured ? S.bg : S.ink,
+                border: featured ? 0 : `1px solid ${S.rule}`,
+                padding: "11px 16px", borderRadius: 10,
+                fontSize: 13, fontWeight: 500, letterSpacing: "-0.005em",
+                display: "inline-flex", alignItems: "center", gap: 8, justifyContent: "center",
+              }}>
+                {featured ? "Open this backup" : "Open"}
+                <Icons.ArrowRight size={14} strokeWidth={1.9}/>
+              </button>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+};
+
+// --- MESSAGES with scrubbable year strip ---
+const Studio_Messages = () => {
+  const { conversations, activeThread } = window.OE_DATA;
+  const Icons = window.OEIcons;
+  const years = [2016, 2017, 2018, 2019, 2020, 2021, 2022, 2023];
+  const activeYearIdx = 7;
+
+  return (
+    <div style={{ flex: 1, display: "flex", flexDirection: "column", minWidth: 0, overflow: "hidden" }}>
+      {/* Scrubbable year strip — novel UX element */}
+      <div style={{
+        padding: "16px 28px 14px",
+        borderBottom: `1px solid ${S.ruleSoft}`,
+        background: `linear-gradient(180deg, ${S.bg}, ${S.surface})`,
+      }}>
+        <div style={{
+          display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: 10,
+        }}>
+          <div style={{ fontFamily: SF.mono, fontSize: 10, color: S.ink3, letterSpacing: "0.16em", textTransform: "uppercase" }}>
+            Drag to travel in time — Emma · 847 messages
+          </div>
+          <div style={{ fontFamily: SF.serif, fontSize: 22, fontStyle: "italic", color: S.accent, letterSpacing: "-0.02em" }}>
+            August 2023
+          </div>
+        </div>
+        <div style={{ position: "relative", height: 56 }}>
+          {/* activity histogram */}
+          <div style={{
+            position: "absolute", inset: 0, display: "flex", alignItems: "end", gap: 2,
+          }}>
+            {Array.from({ length: 96 }).map((_, i) => {
+              const density = 0.3 + Math.abs(Math.sin(i * 0.23)) * 0.6 + (i % 11 === 0 ? 0.15 : 0);
+              const h = 10 + density * 40;
+              const passed = i <= 94;
+              return <div key={i} style={{
+                flex: 1, height: h, borderRadius: 2,
+                background: passed
+                  ? `linear-gradient(180deg, ${S.accent} 0%, rgba(240,160,122,.3) 100%)`
+                  : S.raised,
+                opacity: passed ? 0.9 : 0.5,
+              }}/>;
+            })}
+          </div>
+          {/* year ticks */}
+          <div style={{ position: "absolute", top: 0, left: 0, right: 0, bottom: 0,
+                        display: "flex", alignItems: "flex-end", pointerEvents: "none" }}>
+            {years.map((y, i) => (
+              <div key={y} style={{
+                flex: 1, borderLeft: i === 0 ? "none" : `1px dashed ${S.rule}`,
+                padding: "0 0 -22px 6px", color: i === activeYearIdx ? S.accent : S.ink3,
+                fontFamily: SF.mono, fontSize: 10, letterSpacing: "0.1em",
+                position: "relative", height: "100%",
+              }}>
+                <span style={{ position: "absolute", bottom: -18, left: 6 }}>{y}</span>
+              </div>
+            ))}
+          </div>
+          {/* playhead */}
+          <div style={{
+            position: "absolute", top: -4, bottom: -22,
+            left: "96%", width: 2, background: S.accent,
+            boxShadow: `0 0 14px ${S.accent}`,
+          }}>
+            <div style={{
+              position: "absolute", top: -6, left: -5, width: 12, height: 12,
+              borderRadius: "50%", background: S.accent,
+              boxShadow: `0 0 0 3px rgba(240,160,122,.25)`,
+            }}/>
+          </div>
+        </div>
+      </div>
+
+      <div style={{ flex: 1, display: "flex", minHeight: 0 }}>
+        {/* People rail */}
+        <aside style={{
+          width: 270, flexShrink: 0, borderRight: `1px solid ${S.ruleSoft}`,
+          display: "flex", flexDirection: "column", background: S.bg,
+        }}>
+          <div style={{
+            padding: "16px 18px 12px",
+            display: "flex", alignItems: "center", gap: 8,
+            background: S.surface, border: `1px solid ${S.rule}`, borderRadius: 10,
+            margin: "16px 14px 8px",
+          }}>
+            <Icons.Search size={13} strokeWidth={1.7} stroke={S.ink3}/>
+            <span style={{ fontSize: 12.5, color: S.ink3 }}>Search 214 conversations</span>
+          </div>
+          <div style={{ overflow: "auto", flex: 1, padding: "6px 10px 10px" }}>
+            {conversations.map(c => {
+              const on = c.id === activeThread.contactId;
+              return (
+                <div key={c.id} style={{
+                  display: "flex", gap: 11, padding: "10px 10px",
+                  borderRadius: 10, marginBottom: 1, cursor: "pointer",
+                  background: on ? S.surface : "transparent",
+                  border: `1px solid ${on ? S.rule : "transparent"}`,
+                }}>
+                  <div style={{
+                    width: 36, height: 36, borderRadius: "50%", flexShrink: 0,
+                    background: `oklch(55% 0.12 ${c.avatarHue})`,
+                    display: "flex", alignItems: "center", justifyContent: "center",
+                    color: "#fff", fontFamily: SF.serif, fontSize: 15,
+                  }}>{c.name[0]}</div>
+                  <div style={{ flex: 1, minWidth: 0 }}>
+                    <div style={{ display: "flex", justifyContent: "space-between", alignItems: "baseline" }}>
+                      <span style={{ fontSize: 13.5, color: S.ink, fontWeight: on ? 500 : 400, letterSpacing: "-0.005em" }}>{c.name}</span>
+                      <span style={{ fontSize: 10.5, fontFamily: SF.mono, color: S.ink3 }}>{c.time}</span>
+                    </div>
+                    <div style={{
+                      fontSize: 12.5, color: S.ink2, marginTop: 2,
+                      whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis",
+                    }}>{c.preview}</div>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        </aside>
+
+        {/* Thread */}
+        <section style={{
+          flex: 1, display: "flex", flexDirection: "column", minWidth: 0,
+          background: S.bg,
+        }}>
+          <div style={{
+            padding: "18px 32px", borderBottom: `1px solid ${S.ruleSoft}`,
+            display: "flex", alignItems: "flex-end", gap: 14,
+          }}>
+            <div style={{
+              width: 48, height: 48, borderRadius: "50%",
+              background: `oklch(55% 0.12 14)`,
+              display: "flex", alignItems: "center", justifyContent: "center",
+              color: "#fff", fontFamily: SF.serif, fontSize: 22,
+            }}>E</div>
+            <div style={{ flex: 1 }}>
+              <div style={{ fontFamily: SF.serif, fontSize: 42, fontWeight: 400, letterSpacing: "-0.03em", lineHeight: 1 }}>
+                Emma.
+              </div>
+              <div style={{
+                fontFamily: SF.mono, fontSize: 10.5, color: S.ink3,
+                letterSpacing: "0.12em", textTransform: "uppercase", marginTop: 8,
+              }}>
+                Daughter · 847 messages · Opened Aug 14, 2023
+              </div>
+            </div>
+            <button style={{
+              background: S.accent, color: S.bg, border: 0,
+              padding: "9px 16px", borderRadius: 8, fontSize: 12.5, fontWeight: 600, letterSpacing: "-0.005em",
+              display: "inline-flex", gap: 7, alignItems: "center",
+            }}>
+              <Icons.Export size={13} strokeWidth={2}/>
+              Save thread
+            </button>
+          </div>
+
+          <div style={{ flex: 1, overflow: "auto", padding: "22px 32px 22px" }}>
+            <div style={{
+              fontFamily: SF.mono, fontSize: 10, letterSpacing: "0.14em",
+              color: S.ink3, textAlign: "center", textTransform: "uppercase",
+              marginBottom: 18,
+            }}>
+              ── Monday, Aug 14, 2023 ──
+            </div>
+            {activeThread.messages.map(m => {
+              const mine = m.from === "me";
+              return (
+                <div key={m.id} style={{
+                  display: "flex", justifyContent: mine ? "flex-end" : "flex-start",
+                  marginBottom: 8,
+                }}>
+                  <div style={{
+                    maxWidth: "62%",
+                    background: mine ? S.bubbleMe : S.bubbleThem,
+                    color: mine ? S.bg : S.ink,
+                    padding: m.kind === "photo" ? 6 : "10px 15px",
+                    borderRadius: 16,
+                    border: mine ? "none" : `1px solid ${S.rule}`,
+                    fontSize: 14.5, lineHeight: 1.4, letterSpacing: "-0.005em",
+                  }}>
+                    {m.kind === "photo" ? (
+                      <div>
+                        <div style={{
+                          width: 260, height: 180, borderRadius: 12, overflow: "hidden",
+                          background: `
+                            linear-gradient(135deg, rgba(240,160,122,.35), rgba(197,143,212,.3)),
+                            repeating-linear-gradient(45deg, #3a3145 0 10px, #2d2635 10px 20px)
+                          `,
+                          position: "relative",
+                        }}>
+                          <div style={{
+                            position: "absolute", left: 12, bottom: 10, right: 12,
+                            fontFamily: SF.mono, fontSize: 10.5, color: "#fff6e9",
+                            letterSpacing: "0.04em",
+                          }}>{m.caption}</div>
+                        </div>
+                      </div>
+                    ) : m.text}
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        </section>
+      </div>
+    </div>
+  );
+};
+
+window.StudioRoot = ({ screen }) => {
+  if (screen === "backup") {
+    return (
+      <Studio_Chrome>
+        <div style={{ flex: 1, display: "flex", minHeight: 0 }}>
+          <Studio_Sidebar active="" />
+          <Studio_Backup />
+        </div>
+      </Studio_Chrome>
+    );
+  }
+  if (screen === "messages") {
+    return (
+      <Studio_Chrome>
+        <div style={{ flex: 1, display: "flex", minHeight: 0 }}>
+          <Studio_Sidebar active="messages" />
+          <Studio_Messages />
+        </div>
+      </Studio_Chrome>
+    );
+  }
+  const tokens = {
+    bg: S.bg, surface: S.surface, sunk: S.raised,
+    ink: S.ink, ink2: S.ink2, ink3: S.ink3,
+    rule: S.rule, ruleStr: S.rule,
+    accent: S.accent, accentW: "rgba(240,160,122,0.10)",
+    sans: SF.sans, serif: SF.serif, mono: SF.mono,
+    titleSerif: true, titleWeight: 400, titleLetter: "-0.03em", radius: 8,
+    bubbleMe: S.bubbleMe, bubbleThem: S.bubbleThem,
+    chipActive: S.accent, chipActiveFg: S.bg, chipFg: S.ink2,
+  };
+  return window.SharedScreens.render({
+    screen, tokens,
+    Sidebar: () => <Studio_Sidebar active={screen}/>,
+    Chrome: Studio_Chrome,
+    backupComponent: Studio_Backup, messagesComponent: Studio_Messages,
+  });
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,9 @@
       "version": "0.4.0",
       "license": "MIT",
       "dependencies": {
+        "@fontsource/fraunces": "^5.2.9",
+        "@fontsource/geist": "^5.2.8",
+        "@fontsource/ibm-plex-mono": "^5.2.7",
         "benz-amr-recorder": "^1.1.5",
         "date-fns": "^4.1.0",
         "lucide-react": "^0.577.0",
@@ -23,7 +26,7 @@
         "autoprefixer": "^10.4.19",
         "concurrently": "^8.2.2",
         "electron": "^30.1.0",
-        "electron-builder": "^24.13.3",
+        "electron-builder": "^26.0.12",
         "postcss": "^8.4.38",
         "tailwindcss": "^3.4.4",
         "typescript": "^5.5.2",
@@ -75,7 +78,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -373,10 +375,17 @@
         "node": ">=10.12.0"
       }
     },
+    "node_modules/@electron/asar/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@electron/asar/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -395,6 +404,60 @@
       },
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/@electron/fuses": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@electron/fuses/-/fuses-1.8.0.tgz",
+      "integrity": "sha512-zx0EIq78WlY/lBb1uXlziZmDZI4ubcCXIMJ4uGjXzZW0nS19TjSPeXPAjzzTmKQlJUZm0SbmZhPKP7tuQ1SsEw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.1.1",
+        "fs-extra": "^9.0.1",
+        "minimist": "^1.2.5"
+      },
+      "bin": {
+        "electron-fuses": "dist/bin.js"
+      }
+    },
+    "node_modules/@electron/fuses/node_modules/fs-extra": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "at-least-node": "^1.0.0",
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@electron/fuses/node_modules/jsonfile": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/@electron/fuses/node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
       }
     },
     "node_modules/@electron/get": {
@@ -420,9 +483,9 @@
       }
     },
     "node_modules/@electron/notarize": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/@electron/notarize/-/notarize-2.2.1.tgz",
-      "integrity": "sha512-aL+bFMIkpR0cmmj5Zgy0LMKEpgy43/hw5zadEArgmAMWWlKc5buwFvFT9G/o/YJkvXAJm5q3iuTuLaiaXW39sg==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@electron/notarize/-/notarize-2.5.0.tgz",
+      "integrity": "sha512-jNT8nwH1f9X5GEITXaQ8IF/KdskvIkOFfB2CvwumsveVidzpSc+mvhhTMdAGSYF3O+Nq49lJ7y+ssODRXu06+A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -451,9 +514,9 @@
       }
     },
     "node_modules/@electron/notarize/node_modules/jsonfile": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
-      "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -474,9 +537,9 @@
       }
     },
     "node_modules/@electron/osx-sign": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@electron/osx-sign/-/osx-sign-1.0.5.tgz",
-      "integrity": "sha512-k9ZzUQtamSoweGQDV2jILiRIHUu7lYlJ3c6IEmjv1hC17rclE+eb9U+f6UFlOOETo0JzY1HNlXy4YOlCvl+Lww==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@electron/osx-sign/-/osx-sign-1.3.3.tgz",
+      "integrity": "sha512-KZ8mhXvWv2rIEgMbWZ4y33bDHyUKMXnx4M0sTyPNK/vcB81ImdeY9Ggdqy0SWbMDgmbqyQ+phgejh6V3R2QuSg==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -524,9 +587,9 @@
       }
     },
     "node_modules/@electron/osx-sign/node_modules/jsonfile": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
-      "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -546,56 +609,82 @@
         "node": ">= 10.0.0"
       }
     },
-    "node_modules/@electron/universal": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/@electron/universal/-/universal-1.5.1.tgz",
-      "integrity": "sha512-kbgXxyEauPJiQQUNG2VgUeyfQNFk6hBF11ISN2PNI6agUgPl55pv4eQmaqHzTAzchBvqZ2tQuRVaPStGf0mxGw==",
+    "node_modules/@electron/rebuild": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@electron/rebuild/-/rebuild-4.0.4.tgz",
+      "integrity": "sha512-Rzc39XPdk/+/wBG8MfwAHohXflep0ITUfulb6Rgz3R0NeSB1noE+E9/M/cb8ftCAiyDD9PPhLuuWgE1GaInbKg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@electron/asar": "^3.2.1",
-        "@malept/cross-spawn-promise": "^1.1.0",
-        "debug": "^4.3.1",
-        "dir-compare": "^3.0.0",
-        "fs-extra": "^9.0.1",
-        "minimatch": "^3.0.4",
-        "plist": "^3.0.4"
+        "@malept/cross-spawn-promise": "^2.0.0",
+        "debug": "^4.1.1",
+        "node-abi": "^4.2.0",
+        "node-api-version": "^0.2.1",
+        "node-gyp": "^12.2.0",
+        "read-binary-file-arch": "^1.0.6"
+      },
+      "bin": {
+        "electron-rebuild": "lib/cli.js"
       },
       "engines": {
-        "node": ">=8.6"
+        "node": ">=22.12.0"
       }
     },
-    "node_modules/@electron/universal/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+    "node_modules/@electron/universal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@electron/universal/-/universal-2.0.3.tgz",
+      "integrity": "sha512-Wn9sPYIVFRFl5HmwMJkARCCf7rqK/EurkfQ/rJZ14mHP3iYTjZSIOSVonEAnhWeAXwtw7zOekGRlc6yTtZ0t+g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
+        "@electron/asar": "^3.3.1",
+        "@malept/cross-spawn-promise": "^2.0.0",
+        "debug": "^4.3.1",
+        "dir-compare": "^4.2.0",
+        "fs-extra": "^11.1.1",
+        "minimatch": "^9.0.3",
+        "plist": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=16.4"
+      }
+    },
+    "node_modules/@electron/universal/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@electron/universal/node_modules/brace-expansion": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
       }
     },
     "node_modules/@electron/universal/node_modules/fs-extra": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
-      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+      "version": "11.3.4",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.4.tgz",
+      "integrity": "sha512-CTXd6rk/M3/ULNQj8FBqBWHYBVYybQ3VPBw0xGKFe3tuH7ytT6ACnvzpIQ3UZtB8yvUKC2cXn1a+x+5EVQLovA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "at-least-node": "^1.0.0",
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
         "universalify": "^2.0.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=14.14"
       }
     },
     "node_modules/@electron/universal/node_modules/jsonfile": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
-      "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -606,16 +695,19 @@
       }
     },
     "node_modules/@electron/universal/node_modules/minimatch": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "brace-expansion": "^1.1.7"
+        "brace-expansion": "^2.0.2"
       },
       "engines": {
-        "node": "*"
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/@electron/universal/node_modules/universalify": {
@@ -624,6 +716,72 @@
       "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
       "dev": true,
       "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@electron/windows-sign": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@electron/windows-sign/-/windows-sign-1.2.2.tgz",
+      "integrity": "sha512-dfZeox66AvdPtb2lD8OsIIQh12Tp0GNCRUDfBHIKGpbmopZto2/A8nSpYYLoedPIHpqkeblZ/k8OV0Gy7PYuyQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "cross-dirname": "^0.1.0",
+        "debug": "^4.3.4",
+        "fs-extra": "^11.1.1",
+        "minimist": "^1.2.8",
+        "postject": "^1.0.0-alpha.6"
+      },
+      "bin": {
+        "electron-windows-sign": "bin/electron-windows-sign.js"
+      },
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
+    "node_modules/@electron/windows-sign/node_modules/fs-extra": {
+      "version": "11.3.4",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.4.tgz",
+      "integrity": "sha512-CTXd6rk/M3/ULNQj8FBqBWHYBVYybQ3VPBw0xGKFe3tuH7ytT6ACnvzpIQ3UZtB8yvUKC2cXn1a+x+5EVQLovA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
+    "node_modules/@electron/windows-sign/node_modules/jsonfile": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/@electron/windows-sign/node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       }
@@ -1019,6 +1177,33 @@
         "node": ">=12"
       }
     },
+    "node_modules/@fontsource/fraunces": {
+      "version": "5.2.9",
+      "resolved": "https://registry.npmjs.org/@fontsource/fraunces/-/fraunces-5.2.9.tgz",
+      "integrity": "sha512-XDzuddBtoC7BZgZdBn6b7hsFZY2+V1hgN7yca5fBTKuHjb/lOd45a0Ji8dTUgFhPoL7RdGupo+bC2BFSt6UH8Q==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
+    "node_modules/@fontsource/geist": {
+      "version": "5.2.8",
+      "resolved": "https://registry.npmjs.org/@fontsource/geist/-/geist-5.2.8.tgz",
+      "integrity": "sha512-pI54klK6vz8fVpAVyV+iODGLEzw73cs1XJqV9PIXgW8MYMmBcwK6lKKaWqJrNHwEx8ppz9cuhussb6arXQ/PVQ==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
+    "node_modules/@fontsource/ibm-plex-mono": {
+      "version": "5.2.7",
+      "resolved": "https://registry.npmjs.org/@fontsource/ibm-plex-mono/-/ibm-plex-mono-5.2.7.tgz",
+      "integrity": "sha512-MKAb8qV+CaiMQn2B0dIi1OV3565NYzp3WN5b4oT6LTkk+F0jR6j0ZN+5BKJiIhffDC3rtBULsYZE65+0018z9w==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
     "node_modules/@hapi/hoek": {
       "version": "9.3.0",
       "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
@@ -1036,107 +1221,17 @@
         "@hapi/hoek": "^9.0.0"
       }
     },
-    "node_modules/@isaacs/cliui": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
-      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+    "node_modules/@isaacs/fs-minipass": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
+      "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "string-width": "^5.1.2",
-        "string-width-cjs": "npm:string-width@^4.2.0",
-        "strip-ansi": "^7.0.1",
-        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
-        "wrap-ansi": "^8.1.0",
-        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+        "minipass": "^7.0.4"
       },
       "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@isaacs/cliui/node_modules/ansi-regex": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
-      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
-      }
-    },
-    "node_modules/@isaacs/cliui/node_modules/ansi-styles": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
-      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/@isaacs/cliui/node_modules/emoji-regex": {
-      "version": "9.2.2",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
-      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@isaacs/cliui/node_modules/string-width": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
-      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "eastasianwidth": "^0.2.0",
-        "emoji-regex": "^9.2.2",
-        "strip-ansi": "^7.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@isaacs/cliui/node_modules/strip-ansi": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
-      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^6.2.2"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
-      }
-    },
-    "node_modules/@isaacs/cliui/node_modules/wrap-ansi": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
-      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^6.1.0",
-        "string-width": "^5.0.1",
-        "strip-ansi": "^7.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@jridgewell/gen-mapping": {
@@ -1190,9 +1285,9 @@
       }
     },
     "node_modules/@malept/cross-spawn-promise": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@malept/cross-spawn-promise/-/cross-spawn-promise-1.1.1.tgz",
-      "integrity": "sha512-RTBGWL5FWQcg9orDOCcp4LvItNzUPcyEU9bwaeJX0rJ1IQxzucC48Y0/sQLp/g6t99IQgAlGIaesJS+gTn7tVQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@malept/cross-spawn-promise/-/cross-spawn-promise-2.0.0.tgz",
+      "integrity": "sha512-1DpKU0Z5ThltBwjNySMC14g0CkbyhCaz9FkhxqNsZI6uAPJXFS8cMXlBKo26FJ8ZuW6S9GCMcR9IO5k2X5/9Fg==",
       "dev": true,
       "funding": [
         {
@@ -1209,7 +1304,7 @@
         "cross-spawn": "^7.0.1"
       },
       "engines": {
-        "node": ">= 10"
+        "node": ">= 12.13.0"
       }
     },
     "node_modules/@malept/flatpak-bundler": {
@@ -1245,9 +1340,9 @@
       }
     },
     "node_modules/@malept/flatpak-bundler/node_modules/jsonfile": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
-      "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1303,17 +1398,6 @@
       },
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/@pkgjs/parseargs": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
-      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=14"
       }
     },
     "node_modules/@reduxjs/toolkit": {
@@ -1771,16 +1855,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/@tootallnate/once": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
-      "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 10"
-      }
-    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -1903,9 +1977,9 @@
       "license": "MIT"
     },
     "node_modules/@types/debug": {
-      "version": "4.1.12",
-      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
-      "integrity": "sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==",
+      "version": "4.1.13",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
+      "integrity": "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1988,7 +2062,6 @@
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -2061,9 +2134,9 @@
       }
     },
     "node_modules/@xmldom/xmldom": {
-      "version": "0.8.11",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.11.tgz",
-      "integrity": "sha512-cQzWCtO6C8TQiYl1ruKNn2U6Ao4o4WBBcbL61yJl84x+j5sOWWFU9X7DpND8XZG3daDppSsigMdfAIl2upQBRw==",
+      "version": "0.8.13",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.13.tgz",
+      "integrity": "sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2077,26 +2150,32 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/abbrev": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-4.0.0.tgz",
+      "integrity": "sha512-a1wflyaL0tHtJSmLSOVybYhy22vRih4eduhhrkcjgrWGnRfrZtovJ2FRjxuTtkkj47O/baf0R86QU5OuYpz8fA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
     "node_modules/agent-base": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
-      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "debug": "4"
-      },
       "engines": {
-        "node": ">= 6.0.0"
+        "node": ">= 14"
       }
     },
     "node_modules/ajv": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
-      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -2166,53 +2245,125 @@
       }
     },
     "node_modules/app-builder-bin": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/app-builder-bin/-/app-builder-bin-4.0.0.tgz",
-      "integrity": "sha512-xwdG0FJPQMe0M0UA4Tz0zEB8rBJTRA5a476ZawAqiBkMv16GRK5xpXThOjMaEOFnZ6zabejjG4J3da0SXG63KA==",
+      "version": "5.0.0-alpha.12",
+      "resolved": "https://registry.npmjs.org/app-builder-bin/-/app-builder-bin-5.0.0-alpha.12.tgz",
+      "integrity": "sha512-j87o0j6LqPL3QRr8yid6c+Tt5gC7xNfYo6uQIQkorAC6MpeayVMZrEDzKmJJ/Hlv7EnOQpaRm53k6ktDYZyB6w==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/app-builder-lib": {
-      "version": "24.13.3",
-      "resolved": "https://registry.npmjs.org/app-builder-lib/-/app-builder-lib-24.13.3.tgz",
-      "integrity": "sha512-FAzX6IBit2POXYGnTCT8YHFO/lr5AapAII6zzhQO3Rw4cEDOgK+t1xhLc5tNcKlicTHlo9zxIwnYCX9X2DLkig==",
+      "version": "26.8.1",
+      "resolved": "https://registry.npmjs.org/app-builder-lib/-/app-builder-lib-26.8.1.tgz",
+      "integrity": "sha512-p0Im/Dx5C4tmz8QEE1Yn4MkuPC8PrnlRneMhWJj7BBXQfNTJUshM/bp3lusdEsDbvvfJZpXWnYesgSLvwtM2Zw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@develar/schema-utils": "~2.6.5",
-        "@electron/notarize": "2.2.1",
-        "@electron/osx-sign": "1.0.5",
-        "@electron/universal": "1.5.1",
+        "@electron/asar": "3.4.1",
+        "@electron/fuses": "^1.8.0",
+        "@electron/get": "^3.0.0",
+        "@electron/notarize": "2.5.0",
+        "@electron/osx-sign": "1.3.3",
+        "@electron/rebuild": "^4.0.3",
+        "@electron/universal": "2.0.3",
         "@malept/flatpak-bundler": "^0.4.0",
         "@types/fs-extra": "9.0.13",
         "async-exit-hook": "^2.0.1",
-        "bluebird-lst": "^1.0.9",
-        "builder-util": "24.13.1",
-        "builder-util-runtime": "9.2.4",
+        "builder-util": "26.8.1",
+        "builder-util-runtime": "9.5.1",
         "chromium-pickle-js": "^0.2.0",
+        "ci-info": "4.3.1",
         "debug": "^4.3.4",
+        "dotenv": "^16.4.5",
+        "dotenv-expand": "^11.0.6",
         "ejs": "^3.1.8",
-        "electron-publish": "24.13.1",
-        "form-data": "^4.0.0",
+        "electron-publish": "26.8.1",
         "fs-extra": "^10.1.0",
         "hosted-git-info": "^4.1.0",
-        "is-ci": "^3.0.0",
         "isbinaryfile": "^5.0.0",
+        "jiti": "^2.4.2",
         "js-yaml": "^4.1.0",
+        "json5": "^2.2.3",
         "lazy-val": "^1.0.5",
-        "minimatch": "^5.1.1",
-        "read-config-file": "6.3.2",
-        "sanitize-filename": "^1.6.3",
-        "semver": "^7.3.8",
-        "tar": "^6.1.12",
-        "temp-file": "^3.4.0"
+        "minimatch": "^10.0.3",
+        "plist": "3.1.0",
+        "proper-lockfile": "^4.1.2",
+        "resedit": "^1.7.0",
+        "semver": "~7.7.3",
+        "tar": "^7.5.7",
+        "temp-file": "^3.4.0",
+        "tiny-async-pool": "1.3.0",
+        "which": "^5.0.0"
       },
       "engines": {
         "node": ">=14.0.0"
       },
       "peerDependencies": {
-        "dmg-builder": "24.13.3",
-        "electron-builder-squirrel-windows": "24.13.3"
+        "dmg-builder": "26.8.1",
+        "electron-builder-squirrel-windows": "26.8.1"
+      }
+    },
+    "node_modules/app-builder-lib/node_modules/@electron/get": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@electron/get/-/get-3.1.0.tgz",
+      "integrity": "sha512-F+nKc0xW+kVbBRhFzaMgPy3KwmuNTYX1fx6+FxxoSnNgwYX6LD7AKBTWkU0MQ6IBoe7dz069CNkR673sPAgkCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "env-paths": "^2.2.0",
+        "fs-extra": "^8.1.0",
+        "got": "^11.8.5",
+        "progress": "^2.0.3",
+        "semver": "^6.2.0",
+        "sumchecker": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "optionalDependencies": {
+        "global-agent": "^3.0.0"
+      }
+    },
+    "node_modules/app-builder-lib/node_modules/@electron/get/node_modules/fs-extra": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=6 <7 || >=8"
+      }
+    },
+    "node_modules/app-builder-lib/node_modules/@electron/get/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/app-builder-lib/node_modules/ci-info": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.3.1.tgz",
+      "integrity": "sha512-Wdy2Igu8OcBpI2pZePZ5oWjPC38tmDVx5WKUXKwlLYkA0ozo85sLsLvkBbBn/sZaSCMFOGZJ14fvW9t5/d7kdA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/sibiraj-s"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/app-builder-lib/node_modules/fs-extra": {
@@ -2230,10 +2381,10 @@
         "node": ">=12"
       }
     },
-    "node_modules/app-builder-lib/node_modules/jsonfile": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
-      "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
+    "node_modules/app-builder-lib/node_modules/fs-extra/node_modules/jsonfile": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2241,6 +2392,26 @@
       },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/app-builder-lib/node_modules/fs-extra/node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/app-builder-lib/node_modules/jiti": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
+      "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jiti": "lib/jiti-cli.mjs"
       }
     },
     "node_modules/app-builder-lib/node_modules/semver": {
@@ -2254,90 +2425,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/app-builder-lib/node_modules/universalify": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
-      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
-    "node_modules/archiver": {
-      "version": "5.3.2",
-      "resolved": "https://registry.npmjs.org/archiver/-/archiver-5.3.2.tgz",
-      "integrity": "sha512-+25nxyyznAXF7Nef3y0EbBeqmGZgeN/BxHX29Rs39djAfaFalmQ89SE6CWyDCHzGL0yt/ycBtNOmGTW0FyGWNw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "archiver-utils": "^2.1.0",
-        "async": "^3.2.4",
-        "buffer-crc32": "^0.2.1",
-        "readable-stream": "^3.6.0",
-        "readdir-glob": "^1.1.2",
-        "tar-stream": "^2.2.0",
-        "zip-stream": "^4.1.0"
-      },
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/archiver-utils": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-2.1.0.tgz",
-      "integrity": "sha512-bEL/yUb/fNNiNTuUz979Z0Yg5L+LzLxGJz8x79lYmR54fmTIb6ob/hNQgkQnIUDWIFjZVQwl9Xs356I6BAMHfw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "glob": "^7.1.4",
-        "graceful-fs": "^4.2.0",
-        "lazystream": "^1.0.0",
-        "lodash.defaults": "^4.2.0",
-        "lodash.difference": "^4.5.0",
-        "lodash.flatten": "^4.4.0",
-        "lodash.isplainobject": "^4.0.6",
-        "lodash.union": "^4.6.0",
-        "normalize-path": "^3.0.0",
-        "readable-stream": "^2.0.0"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/archiver-utils/node_modules/readable-stream": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
-      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
-      }
-    },
-    "node_modules/archiver-utils/node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/archiver-utils/node_modules/string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "~5.1.0"
       }
     },
     "node_modules/arg": {
@@ -2460,11 +2547,14 @@
       }
     },
     "node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
     },
     "node_modules/base64-js": {
       "version": "1.5.1",
@@ -2528,35 +2618,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/bl": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
-      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "buffer": "^5.5.0",
-        "inherits": "^2.0.4",
-        "readable-stream": "^3.4.0"
-      }
-    },
-    "node_modules/bluebird": {
-      "version": "3.7.2",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
-      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/bluebird-lst": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/bluebird-lst/-/bluebird-lst-1.0.9.tgz",
-      "integrity": "sha512-7B1Rtx82hjnSD4PGLAjVWeYH3tHAcVUmChh85a3lltKQm6FresXh9ErQo6oAv6CqxttczC3/kEg8SY5NluPuUw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "bluebird": "^3.5.5"
-      }
-    },
     "node_modules/boolean": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/boolean/-/boolean-3.2.0.tgz",
@@ -2567,13 +2628,16 @@
       "optional": true
     },
     "node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "balanced-match": "^1.0.0"
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/braces": {
@@ -2609,7 +2673,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -2644,6 +2707,7 @@
         }
       ],
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.1.13"
@@ -2659,19 +2723,6 @@
         "node": "*"
       }
     },
-    "node_modules/buffer-equal": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/buffer-equal/-/buffer-equal-1.0.1.tgz",
-      "integrity": "sha512-QoV3ptgEaQpvVwbXdSO39iqPQTCxSF7A5U99AxbHYqUdCizL/lH2Z0A2y6nbZucxMEOtNyZfG2s6gsVugGpKkg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/buffer-from": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
@@ -2680,34 +2731,34 @@
       "license": "MIT"
     },
     "node_modules/builder-util": {
-      "version": "24.13.1",
-      "resolved": "https://registry.npmjs.org/builder-util/-/builder-util-24.13.1.tgz",
-      "integrity": "sha512-NhbCSIntruNDTOVI9fdXz0dihaqX2YuE1D6zZMrwiErzH4ELZHE6mdiB40wEgZNprDia+FghRFgKoAqMZRRjSA==",
+      "version": "26.8.1",
+      "resolved": "https://registry.npmjs.org/builder-util/-/builder-util-26.8.1.tgz",
+      "integrity": "sha512-pm1lTYbGyc90DHgCDO7eo8Rl4EqKLciayNbZqGziqnH9jrlKe8ZANGdityLZU+pJh16dfzjAx2xQq9McuIPEtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/debug": "^4.1.6",
         "7zip-bin": "~5.2.0",
-        "app-builder-bin": "4.0.0",
-        "bluebird-lst": "^1.0.9",
-        "builder-util-runtime": "9.2.4",
+        "app-builder-bin": "5.0.0-alpha.12",
+        "builder-util-runtime": "9.5.1",
         "chalk": "^4.1.2",
-        "cross-spawn": "^7.0.3",
+        "cross-spawn": "^7.0.6",
         "debug": "^4.3.4",
         "fs-extra": "^10.1.0",
-        "http-proxy-agent": "^5.0.0",
-        "https-proxy-agent": "^5.0.1",
-        "is-ci": "^3.0.0",
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.0",
         "js-yaml": "^4.1.0",
+        "sanitize-filename": "^1.6.3",
         "source-map-support": "^0.5.19",
         "stat-mode": "^1.0.0",
-        "temp-file": "^3.4.0"
+        "temp-file": "^3.4.0",
+        "tiny-async-pool": "1.3.0"
       }
     },
     "node_modules/builder-util-runtime": {
-      "version": "9.2.4",
-      "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.2.4.tgz",
-      "integrity": "sha512-upp+biKpN/XZMLim7aguUyW8s0FUpDvOtK6sbanMFDAMBzpHDqdhgVYm6zc9HJ6nWo7u2Lxk60i2M6Jd3aiNrA==",
+      "version": "9.5.1",
+      "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.5.1.tgz",
+      "integrity": "sha512-qt41tMfgHTllhResqM5DcnHyDIWNgzHvuY2jDcYP9iaGpkWxTUzV6GQjDeLnlR1/DtdlcsWQbA7sByMpmJFTLQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2734,9 +2785,9 @@
       }
     },
     "node_modules/builder-util/node_modules/jsonfile": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
-      "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2899,13 +2950,13 @@
       }
     },
     "node_modules/chownr": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
-      "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
+      "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
       "dev": true,
-      "license": "ISC",
+      "license": "BlueOak-1.0.0",
       "engines": {
-        "node": ">=10"
+        "node": ">=18"
       }
     },
     "node_modules/chromium-pickle-js": {
@@ -2916,9 +2967,9 @@
       "license": "MIT"
     },
     "node_modules/ci-info": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
-      "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.4.0.tgz",
+      "integrity": "sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==",
       "dev": true,
       "funding": [
         {
@@ -3039,22 +3090,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/compress-commons": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-4.1.2.tgz",
-      "integrity": "sha512-D3uMHtGc/fcO1Gt1/L7i1e33VOvD4A9hfQLP+6ewd+BvG/gQ84Yh4oftEhAdjSMgBgwGL+jsppT7JYNpo6MHHg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "buffer-crc32": "^0.2.13",
-        "crc32-stream": "^4.0.2",
-        "normalize-path": "^3.0.0",
-        "readable-stream": "^3.6.0"
-      },
-      "engines": {
-        "node": ">= 10"
-      }
-    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -3107,65 +3142,6 @@
         "url": "https://opencollective.com/date-fns"
       }
     },
-    "node_modules/config-file-ts": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/config-file-ts/-/config-file-ts-0.2.6.tgz",
-      "integrity": "sha512-6boGVaglwblBgJqGyxm4+xCmEGcWgnWHSWHY5jad58awQhB6gftq0G8HbzU39YqCIYHMLAiL1yjwiZ36m/CL8w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "glob": "^10.3.10",
-        "typescript": "^5.3.3"
-      }
-    },
-    "node_modules/config-file-ts/node_modules/glob": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
-      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
-      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "foreground-child": "^3.1.0",
-        "jackspeak": "^3.1.2",
-        "minimatch": "^9.0.4",
-        "minipass": "^7.1.2",
-        "package-json-from-dist": "^1.0.0",
-        "path-scurry": "^1.11.1"
-      },
-      "bin": {
-        "glob": "dist/esm/bin.mjs"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/config-file-ts/node_modules/minimatch": {
-      "version": "9.0.9",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
-      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.2"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/config-file-ts/node_modules/minipass": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
-      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      }
-    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
@@ -3178,7 +3154,8 @@
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/crc": {
       "version": "3.8.0",
@@ -3191,32 +3168,14 @@
         "buffer": "^5.1.0"
       }
     },
-    "node_modules/crc-32": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
-      "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "crc32": "bin/crc32.njs"
-      },
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
-    "node_modules/crc32-stream": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-4.0.3.tgz",
-      "integrity": "sha512-NT7w2JVU7DFroFdYkeq8cywxrgjPHWkdX1wjpRQXPX5Asews3tA+Ght6lddQO5Mkumffp3X7GEqku3epj2toIw==",
+    "node_modules/cross-dirname": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/cross-dirname/-/cross-dirname-0.1.0.tgz",
+      "integrity": "sha512-+R08/oI0nl3vfPcqftZRpytksBXDzOUveBq/NBVx0sUp1axwzPQrKinNx5yd5sxPu8j1wIy8AfnVQ+5eFdha6Q==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "crc-32": "^1.2.0",
-        "readable-stream": "^3.4.0"
-      },
-      "engines": {
-        "node": ">= 10"
-      }
+      "optional": true,
+      "peer": true
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -3228,6 +3187,29 @@
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
         "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/cross-spawn/node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/cross-spawn/node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
       },
       "engines": {
         "node": ">= 8"
@@ -3511,20 +3493,27 @@
       "license": "Apache-2.0"
     },
     "node_modules/dir-compare": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/dir-compare/-/dir-compare-3.3.0.tgz",
-      "integrity": "sha512-J7/et3WlGUCxjdnD3HAAzQ6nsnc0WL6DD7WcwJb7c39iH1+AWfg+9OqzJNaI6PkBwBvm1mhZNL9iY/nRiZXlPg==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/dir-compare/-/dir-compare-4.2.0.tgz",
+      "integrity": "sha512-2xMCmOoMrdQIPHdsTawECdNPwlVFB9zGcz3kuhmBO6U3oU+UQjsue0i8ayLKpgBcm+hcXPMVSGUN9d+pvJ6+VQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "buffer-equal": "^1.0.0",
-        "minimatch": "^3.0.4"
+        "minimatch": "^3.0.5",
+        "p-limit": "^3.1.0 "
       }
     },
+    "node_modules/dir-compare/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/dir-compare/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3553,16 +3542,14 @@
       "license": "MIT"
     },
     "node_modules/dmg-builder": {
-      "version": "24.13.3",
-      "resolved": "https://registry.npmjs.org/dmg-builder/-/dmg-builder-24.13.3.tgz",
-      "integrity": "sha512-rcJUkMfnJpfCboZoOOPf4L29TRtEieHNOeAbYPWPxlaBw/Z1RKrRA86dOI9rwaI4tQSc/RD82zTNHprfUHXsoQ==",
+      "version": "26.8.1",
+      "resolved": "https://registry.npmjs.org/dmg-builder/-/dmg-builder-26.8.1.tgz",
+      "integrity": "sha512-glMJgnTreo8CFINujtAhCgN96QAqApDMZ8Vl1r8f0QT8QprvC1UCltV4CcWj20YoIyLZx6IUskaJZ0NV8fokcg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "app-builder-lib": "24.13.3",
-        "builder-util": "24.13.1",
-        "builder-util-runtime": "9.2.4",
+        "app-builder-lib": "26.8.1",
+        "builder-util": "26.8.1",
         "fs-extra": "^10.1.0",
         "iconv-lite": "^0.6.2",
         "js-yaml": "^4.1.0"
@@ -3587,9 +3574,9 @@
       }
     },
     "node_modules/dmg-builder/node_modules/jsonfile": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
-      "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3637,21 +3624,33 @@
       }
     },
     "node_modules/dotenv": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-9.0.2.tgz",
-      "integrity": "sha512-I9OvvrHp4pIARv4+x9iuewrWycX6CcZtoAu1XrzPxc5UygMJXJZYmBsynku8IkrJwgypE5DGNjDPmPRhDCptUg==",
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
       "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
-        "node": ">=10"
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/dotenv-expand": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-5.1.0.tgz",
-      "integrity": "sha512-YXQl1DSa4/PQyRfgrv6aoNjhasp/p4qs9FjJ4q4cQk+8m4r6k4ZSiEyytKG8f8W9gi8WsQtIObNmKd+tMzNTmA==",
+      "version": "11.0.7",
+      "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-11.0.7.tgz",
+      "integrity": "sha512-zIHwmZPRshsCdpMDyVsqGmgyP0yT8GAgXUnkdAoJisxvf33k7yO6OuoKmcTGuXPWSsm8Oh88nZicRLA9Y0rUeA==",
       "dev": true,
-      "license": "BSD-2-Clause"
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dotenv": "^16.4.5"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -3667,13 +3666,6 @@
       "engines": {
         "node": ">= 0.4"
       }
-    },
-    "node_modules/eastasianwidth": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
-      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/ejs": {
       "version": "3.1.10",
@@ -3711,21 +3703,20 @@
       }
     },
     "node_modules/electron-builder": {
-      "version": "24.13.3",
-      "resolved": "https://registry.npmjs.org/electron-builder/-/electron-builder-24.13.3.tgz",
-      "integrity": "sha512-yZSgVHft5dNVlo31qmJAe4BVKQfFdwpRw7sFp1iQglDRCDD6r22zfRJuZlhtB5gp9FHUxCMEoWGq10SkCnMAIg==",
+      "version": "26.8.1",
+      "resolved": "https://registry.npmjs.org/electron-builder/-/electron-builder-26.8.1.tgz",
+      "integrity": "sha512-uWhx1r74NGpCagG0ULs/P9Nqv2nsoo+7eo4fLUOB8L8MdWltq9odW/uuLXMFCDGnPafknYLZgjNX0ZIFRzOQAw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "app-builder-lib": "24.13.3",
-        "builder-util": "24.13.1",
-        "builder-util-runtime": "9.2.4",
+        "app-builder-lib": "26.8.1",
+        "builder-util": "26.8.1",
+        "builder-util-runtime": "9.5.1",
         "chalk": "^4.1.2",
-        "dmg-builder": "24.13.3",
+        "ci-info": "^4.2.0",
+        "dmg-builder": "26.8.1",
         "fs-extra": "^10.1.0",
-        "is-ci": "^3.0.0",
         "lazy-val": "^1.0.5",
-        "read-config-file": "6.3.2",
         "simple-update-notifier": "2.0.0",
         "yargs": "^17.6.2"
       },
@@ -3738,54 +3729,16 @@
       }
     },
     "node_modules/electron-builder-squirrel-windows": {
-      "version": "24.13.3",
-      "resolved": "https://registry.npmjs.org/electron-builder-squirrel-windows/-/electron-builder-squirrel-windows-24.13.3.tgz",
-      "integrity": "sha512-oHkV0iogWfyK+ah9ZIvMDpei1m9ZRpdXcvde1wTpra2U8AFDNNpqJdnin5z+PM1GbQ5BoaKCWas2HSjtR0HwMg==",
+      "version": "26.8.1",
+      "resolved": "https://registry.npmjs.org/electron-builder-squirrel-windows/-/electron-builder-squirrel-windows-26.8.1.tgz",
+      "integrity": "sha512-o288fIdgPLHA76eDrFADHPoo7VyGkDCYbLV1GzndaMSAVBoZrGvM9m2IehdcVMzdAZJ2eV9bgyissQXHv5tGzA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
-        "app-builder-lib": "24.13.3",
-        "archiver": "^5.3.1",
-        "builder-util": "24.13.1",
-        "fs-extra": "^10.1.0"
-      }
-    },
-    "node_modules/electron-builder-squirrel-windows/node_modules/fs-extra": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
-      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/electron-builder-squirrel-windows/node_modules/jsonfile": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
-      "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "universalify": "^2.0.0"
-      },
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
-      }
-    },
-    "node_modules/electron-builder-squirrel-windows/node_modules/universalify": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
-      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 10.0.0"
+        "app-builder-lib": "26.8.1",
+        "builder-util": "26.8.1",
+        "electron-winstaller": "5.4.0"
       }
     },
     "node_modules/electron-builder/node_modules/fs-extra": {
@@ -3827,16 +3780,17 @@
       }
     },
     "node_modules/electron-publish": {
-      "version": "24.13.1",
-      "resolved": "https://registry.npmjs.org/electron-publish/-/electron-publish-24.13.1.tgz",
-      "integrity": "sha512-2ZgdEqJ8e9D17Hwp5LEq5mLQPjqU3lv/IALvgp+4W8VeNhryfGhYEQC/PgDPMrnWUp+l60Ou5SJLsu+k4mhQ8A==",
+      "version": "26.8.1",
+      "resolved": "https://registry.npmjs.org/electron-publish/-/electron-publish-26.8.1.tgz",
+      "integrity": "sha512-q+jrSTIh/Cv4eGZa7oVR+grEJo/FoLMYBAnSL5GCtqwUpr1T+VgKB/dn1pnzxIxqD8S/jP1yilT9VrwCqINR4w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/fs-extra": "^9.0.11",
-        "builder-util": "24.13.1",
-        "builder-util-runtime": "9.2.4",
+        "builder-util": "26.8.1",
+        "builder-util-runtime": "9.5.1",
         "chalk": "^4.1.2",
+        "form-data": "^4.0.5",
         "fs-extra": "^10.1.0",
         "lazy-val": "^1.0.5",
         "mime": "^2.5.2"
@@ -3858,9 +3812,9 @@
       }
     },
     "node_modules/electron-publish/node_modules/jsonfile": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
-      "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3886,6 +3840,44 @@
       "integrity": "sha512-5z3uFKBWjiNR44nFcYdkcXjKMbg5KXNdciu7mhTPo9tB7NbqSNP2sSnGR+fqknZSCwKkBN+oxiiajWs4dT6ORg==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/electron-winstaller": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/electron-winstaller/-/electron-winstaller-5.4.0.tgz",
+      "integrity": "sha512-bO3y10YikuUwUuDUQRM4KfwNkKhnpVO7IPdbsrejwN9/AABJzzTQ4GeHwyzNSrVO+tEH3/Np255a3sVZpZDjvg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@electron/asar": "^3.2.1",
+        "debug": "^4.1.1",
+        "fs-extra": "^7.0.1",
+        "lodash": "^4.17.21",
+        "temp": "^0.9.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@electron/windows-sign": "^1.1.2"
+      }
+    },
+    "node_modules/electron-winstaller/node_modules/fs-extra": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+      "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "graceful-fs": "^4.1.2",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=6 <7 || >=8"
+      }
     },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
@@ -4057,6 +4049,13 @@
       "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
       "license": "MIT"
     },
+    "node_modules/exponential-backoff": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/exponential-backoff/-/exponential-backoff-3.1.3.tgz",
+      "integrity": "sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
     "node_modules/extract-zip": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
@@ -4163,6 +4162,36 @@
         "minimatch": "^5.0.1"
       }
     },
+    "node_modules/filelist/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/filelist/node_modules/brace-expansion": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/filelist/node_modules/minimatch": {
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/fill-range": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
@@ -4197,23 +4226,6 @@
         }
       }
     },
-    "node_modules/foreground-child": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
-      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "cross-spawn": "^7.0.6",
-        "signal-exit": "^4.0.1"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/form-data": {
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
@@ -4245,13 +4257,6 @@
         "url": "https://github.com/sponsors/rawify"
       }
     },
-    "node_modules/fs-constants": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
-      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/fs-extra": {
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
@@ -4266,39 +4271,6 @@
       "engines": {
         "node": ">=6 <7 || >=8"
       }
-    },
-    "node_modules/fs-minipass": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
-      "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "minipass": "^3.0.0"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/fs-minipass/node_modules/minipass": {
-      "version": "3.3.6",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
-      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/fs-minipass/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true,
-      "license": "ISC"
     },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
@@ -4442,10 +4414,17 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/glob/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4670,18 +4649,17 @@
       "license": "BSD-2-Clause"
     },
     "node_modules/http-proxy-agent": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
-      "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@tootallnate/once": "2",
-        "agent-base": "6",
-        "debug": "4"
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
       },
       "engines": {
-        "node": ">= 6"
+        "node": ">= 14"
       }
     },
     "node_modules/http2-wrapper": {
@@ -4699,17 +4677,17 @@
       }
     },
     "node_modules/https-proxy-agent": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
-      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "agent-base": "6",
+        "agent-base": "^7.1.2",
         "debug": "4"
       },
       "engines": {
-        "node": ">= 6"
+        "node": ">= 14"
       }
     },
     "node_modules/iconv-corefoundation": {
@@ -4762,7 +4740,8 @@
           "url": "https://feross.org/support"
         }
       ],
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "optional": true
     },
     "node_modules/immer": {
       "version": "10.2.0",
@@ -4813,19 +4792,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/is-ci": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-3.0.1.tgz",
-      "integrity": "sha512-ZYvCgrefwqoQ6yTyYUbQu64HsITZ3NfKX1lzaEYdkTDcfKzzCI/wthRRYKkdjHKFVgNiXKAKm65Zo1pk2as/QQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ci-info": "^3.2.0"
-      },
-      "bin": {
-        "is-ci": "bin.js"
       }
     },
     "node_modules/is-core-module": {
@@ -4887,13 +4853,6 @@
         "node": ">=0.12.0"
       }
     },
-    "node_modules/isarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/isbinaryfile": {
       "version": "5.0.7",
       "resolved": "https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-5.0.7.tgz",
@@ -4908,26 +4867,13 @@
       }
     },
     "node_modules/isexe": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/jackspeak": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
-      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-3.1.5.tgz",
+      "integrity": "sha512-6B3tLtFqtQS4ekarvLVMZ+X+VlvQekbe4taUkf/rhVO3d/h0M2rfARm/pXLcPEsjjMsFgrFgSrhQIxcSVrBz8w==",
       "dev": true,
       "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "@isaacs/cliui": "^8.0.2"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      },
-      "optionalDependencies": {
-        "@pkgjs/parseargs": "^0.11.0"
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/jake": {
@@ -4954,7 +4900,6 @@
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -5067,52 +5012,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/lazystream": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.1.tgz",
-      "integrity": "sha512-b94GiNHQNy6JNTrt5w6zNyffMrNkXZb3KTkCZJb2V1xaEGCk093vkZ2jk3tpaeP33/OiXC+WvK9AxUebnf5nbw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "readable-stream": "^2.0.5"
-      },
-      "engines": {
-        "node": ">= 0.6.3"
-      }
-    },
-    "node_modules/lazystream/node_modules/readable-stream": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
-      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
-      }
-    },
-    "node_modules/lazystream/node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/lazystream/node_modules/string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "~5.1.0"
-      }
-    },
     "node_modules/lilconfig": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
@@ -5137,41 +5036,6 @@
       "version": "4.17.23",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
       "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/lodash.defaults": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
-      "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/lodash.difference": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.difference/-/lodash.difference-4.5.0.tgz",
-      "integrity": "sha512-dS2j+W26TQ7taQBGN8Lbbq04ssV3emRw4NY58WErlTO29pIqS0HmoT5aJ9+TUQ1N3G+JOZSji4eugsWwGp9yPA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/lodash.flatten": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
-      "integrity": "sha512-C5N2Z3DgnnKr0LOpv/hKCgKdb7ZZwafIrsesve6lmzvZIRZRGaZ/l6Q8+2W7NaT+ZwO3fFlSCzCzrDCFdJfZ4g==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/lodash.isplainobject": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
-      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/lodash.union": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/lodash.union/-/lodash.union-4.6.0.tgz",
-      "integrity": "sha512-c4pB2CdGrGdjMKYLA+XiRDO7Y0PRQbm/Gzg8qMj+QH+pFVAoTp5sBpO0odL3FjoPCGjK96p6qsP+yQoiLoOBcw==",
       "dev": true,
       "license": "MIT"
     },
@@ -5311,16 +5175,19 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "5.1.9",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
-      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
       "dev": true,
-      "license": "ISC",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "brace-expansion": "^5.0.5"
       },
       "engines": {
-        "node": ">=10"
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/minimist": {
@@ -5334,60 +5201,40 @@
       }
     },
     "node_modules/minipass": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
-      "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
       "dev": true,
-      "license": "ISC",
+      "license": "BlueOak-1.0.0",
       "engines": {
-        "node": ">=8"
+        "node": ">=16 || 14 >=14.17"
       }
     },
     "node_modules/minizlib": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
-      "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
+      "integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "minipass": "^3.0.0",
-        "yallist": "^4.0.0"
+        "minipass": "^7.1.2"
       },
       "engines": {
-        "node": ">= 8"
+        "node": ">= 18"
       }
-    },
-    "node_modules/minizlib/node_modules/minipass": {
-      "version": "3.3.6",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
-      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/minizlib/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true,
-      "license": "ISC"
     },
     "node_modules/mkdirp": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "minimist": "^1.2.6"
+      },
       "bin": {
         "mkdirp": "bin/cmd.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/ms": {
@@ -5428,6 +5275,32 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/node-abi": {
+      "version": "4.28.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-4.28.0.tgz",
+      "integrity": "sha512-Qfp5XZL1cJDOabOT8H5gnqMTmM4NjvYzHp4I/Kt/Sl76OVkOBBHRFlPspGV0hYvMoqQsypFjT/Yp7Km0beXW9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.6.3"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
+    "node_modules/node-abi/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/node-addon-api": {
       "version": "1.7.2",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-1.7.2.tgz",
@@ -5436,12 +5309,115 @@
       "license": "MIT",
       "optional": true
     },
+    "node_modules/node-api-version": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/node-api-version/-/node-api-version-0.2.1.tgz",
+      "integrity": "sha512-2xP/IGGMmmSQpI1+O/k72jF/ykvZ89JeuKX3TLJAYPDVLUalrshrLHkeVcCCZqG/eEa635cr8IBYzgnDvM2O8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.3.5"
+      }
+    },
+    "node_modules/node-api-version/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/node-gyp": {
+      "version": "12.3.0",
+      "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-12.3.0.tgz",
+      "integrity": "sha512-QNcUWM+HgJplcPzBvFBZ9VXacyGZ4+VTOb80PwWR+TlVzoHbRKULNEzpRsnaoxG3Wzr7Qh7BYxGDU3CbKib2Yg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "env-paths": "^2.2.0",
+        "exponential-backoff": "^3.1.1",
+        "graceful-fs": "^4.2.6",
+        "nopt": "^9.0.0",
+        "proc-log": "^6.0.0",
+        "semver": "^7.3.5",
+        "tar": "^7.5.4",
+        "tinyglobby": "^0.2.12",
+        "undici": "^6.25.0",
+        "which": "^6.0.0"
+      },
+      "bin": {
+        "node-gyp": "bin/node-gyp.js"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/node-gyp/node_modules/isexe": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-4.0.0.tgz",
+      "integrity": "sha512-FFUtZMpoZ8RqHS3XeXEmHWLA4thH+ZxCv2lOiPIn1Xc7CxrqhWzNSDzD+/chS/zbYezmiwWLdQC09JdQKmthOw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/node-gyp/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/node-gyp/node_modules/which": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-6.0.1.tgz",
+      "integrity": "sha512-oGLe46MIrCRqX7ytPUf66EAYvdeMIZYn3WaocqqKZAxrBpkqHfL/qvTyJ/bTk5+AqHCjXmrv3CEWgy368zhRUg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^4.0.0"
+      },
+      "bin": {
+        "node-which": "bin/which.js"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
     "node_modules/node-releases": {
       "version": "2.0.36",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.36.tgz",
       "integrity": "sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/nopt": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-9.0.0.tgz",
+      "integrity": "sha512-Zhq3a+yFKrYwSBluL4H9XP3m3y5uvQkB/09CwDruCiRmR/UJYnn9W4R48ry0uGC70aeTPKLynBtscP9efFFcPw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "abbrev": "^4.0.0"
+      },
+      "bin": {
+        "nopt": "bin/nopt.js"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",
@@ -5517,12 +5493,21 @@
         "node": ">=8"
       }
     },
-    "node_modules/package-json-from-dist": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
-      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
       "dev": true,
-      "license": "BlueOak-1.0.0"
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/path-is-absolute": {
       "version": "1.0.1",
@@ -5551,29 +5536,20 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/path-scurry": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
-      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+    "node_modules/pe-library": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/pe-library/-/pe-library-0.4.1.tgz",
+      "integrity": "sha512-eRWB5LBz7PpDu4PUlwT0PhnQfTQJlDDdPa35urV4Osrm0t0AqQFGn+UIkU3klZvwJ8KPO3VbBFsXquA6p6kqZw==",
       "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "lru-cache": "^10.2.0",
-        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
-      },
+      "license": "MIT",
       "engines": {
-        "node": ">=16 || 14 >=14.18"
+        "node": ">=12",
+        "npm": ">=6"
       },
       "funding": {
-        "url": "https://github.com/sponsors/isaacs"
+        "type": "github",
+        "url": "https://github.com/sponsors/jet2jet"
       }
-    },
-    "node_modules/path-scurry/node_modules/lru-cache": {
-      "version": "10.4.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
-      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
-      "dev": true,
-      "license": "ISC"
     },
     "node_modules/pend": {
       "version": "1.2.0",
@@ -5657,7 +5633,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -5801,12 +5776,45 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/process-nextick-args": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+    "node_modules/postject": {
+      "version": "1.0.0-alpha.6",
+      "resolved": "https://registry.npmjs.org/postject/-/postject-1.0.0-alpha.6.tgz",
+      "integrity": "sha512-b9Eb8h2eVqNE8edvKdwqkrY6O7kAwmI8kcnBv1NScolYJbo59XUF0noFq+lxbC1yN20bmC0WBEbDC5H/7ASb0A==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "commander": "^9.4.0"
+      },
+      "bin": {
+        "postject": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/postject/node_modules/commander": {
+      "version": "9.5.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
+      "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": "^12.20.0 || >=14"
+      }
+    },
+    "node_modules/proc-log": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-6.1.0.tgz",
+      "integrity": "sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
     },
     "node_modules/progress": {
       "version": "2.0.3",
@@ -5830,6 +5838,18 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/proper-lockfile": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-4.1.2.tgz",
+      "integrity": "sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.4",
+        "retry": "^0.12.0",
+        "signal-exit": "^3.0.2"
       }
     },
     "node_modules/proxy-from-env": {
@@ -5899,7 +5919,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -5912,7 +5931,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -5933,7 +5951,6 @@
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
       "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/use-sync-external-store": "^0.0.6",
         "use-sync-external-store": "^1.4.0"
@@ -5962,6 +5979,19 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/read-binary-file-arch": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/read-binary-file-arch/-/read-binary-file-arch-1.0.6.tgz",
+      "integrity": "sha512-BNg9EN3DD3GsDXX7Aa8O4p92sryjkmzYYgmgTAc6CA4uGLEDzFfxOxugu21akOxpcXHiEgsYkC6nPsQvLLLmEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.4"
+      },
+      "bin": {
+        "read-binary-file-arch": "cli.js"
+      }
+    },
     "node_modules/read-cache": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
@@ -5970,49 +6000,6 @@
       "license": "MIT",
       "dependencies": {
         "pify": "^2.3.0"
-      }
-    },
-    "node_modules/read-config-file": {
-      "version": "6.3.2",
-      "resolved": "https://registry.npmjs.org/read-config-file/-/read-config-file-6.3.2.tgz",
-      "integrity": "sha512-M80lpCjnE6Wt6zb98DoW8WHR09nzMSpu8XHtPkiTHrJ5Az9CybfeQhTJ8D7saeBHpGhLPIVyA8lcL6ZmdKwY6Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "config-file-ts": "^0.2.4",
-        "dotenv": "^9.0.2",
-        "dotenv-expand": "^5.1.0",
-        "js-yaml": "^4.1.0",
-        "json5": "^2.2.0",
-        "lazy-val": "^1.0.4"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      }
-    },
-    "node_modules/readable-stream": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/readdir-glob": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/readdir-glob/-/readdir-glob-1.1.3.tgz",
-      "integrity": "sha512-v05I2k7xN8zXvPD9N+z/uhXPaj0sUFCe2rcWZIpBsqxfP7xXFQ0tipAd/wjj1YxWyWtUS5IDJpOG82JKt2EAVA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "minimatch": "^5.1.0"
       }
     },
     "node_modules/readdirp": {
@@ -6062,8 +6049,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/redux-thunk": {
       "version": "3.1.0",
@@ -6082,6 +6068,24 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/resedit": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/resedit/-/resedit-1.7.2.tgz",
+      "integrity": "sha512-vHjcY2MlAITJhC0eRD/Vv8Vlgmu9Sd3LX9zZvtGzU5ZImdTN3+d6e/4mnTyV8vEbyf1sgNIrWxhWlrys52OkEA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pe-library": "^0.4.1"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/jet2jet"
       }
     },
     "node_modules/reselect": {
@@ -6150,6 +6154,21 @@
       "engines": {
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rimraf": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+      "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "dev": true,
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
       }
     },
     "node_modules/roarr": {
@@ -6250,27 +6269,6 @@
         "tslib": "^2.1.0"
       }
     },
-    "node_modules/safe-buffer": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
-    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
@@ -6279,9 +6277,9 @@
       "license": "MIT"
     },
     "node_modules/sanitize-filename": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/sanitize-filename/-/sanitize-filename-1.6.3.tgz",
-      "integrity": "sha512-y/52Mcy7aw3gRm7IrcGDFx/bCk4AhRh2eI9luHOQM86nZsqwiRkkq2GekHXBBD+SmPidc8i2PqtYZl+pWJ8Oeg==",
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/sanitize-filename/-/sanitize-filename-1.6.4.tgz",
+      "integrity": "sha512-9ZyI08PsvdQl2r/bBIGubpVdR3RR9sY6RDiWFPreA21C/EFlQhmgo20UZlNjZMMZNubusLhAQozkA0Od5J21Eg==",
       "dev": true,
       "license": "WTFPL OR ISC",
       "dependencies": {
@@ -6289,9 +6287,9 @@
       }
     },
     "node_modules/sax": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.5.0.tgz",
-      "integrity": "sha512-21IYA3Q5cQf089Z6tgaUTr7lDAyzoTPx5HRtbhsME8Udispad8dC/+sziTNugOEx54ilvatQ9YCzl4KQLPcRHA==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
+      "integrity": "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
@@ -6379,17 +6377,11 @@
       }
     },
     "node_modules/signal-exit": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
-      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
+      "license": "ISC"
     },
     "node_modules/simple-update-notifier": {
       "version": "2.0.0",
@@ -6500,16 +6492,6 @@
         "node": ">= 6"
       }
     },
-    "node_modules/string_decoder": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "~5.2.0"
-      }
-    },
     "node_modules/string-width": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
@@ -6525,37 +6507,7 @@
         "node": ">=8"
       }
     },
-    "node_modules/string-width-cjs": {
-      "name": "string-width",
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/strip-ansi-cjs": {
-      "name": "strip-ansi",
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
@@ -6682,47 +6634,46 @@
       }
     },
     "node_modules/tar": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
-      "integrity": "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==",
-      "deprecated": "Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "version": "7.5.13",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.13.tgz",
+      "integrity": "sha512-tOG/7GyXpFevhXVh8jOPJrmtRpOTsYqUIkVdVooZYJS/z8WhfQUX8RJILmeuJNinGAMSu1veBr4asSHFt5/hng==",
       "dev": true,
-      "license": "ISC",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
-        "chownr": "^2.0.0",
-        "fs-minipass": "^2.0.0",
-        "minipass": "^5.0.0",
-        "minizlib": "^2.1.1",
-        "mkdirp": "^1.0.3",
-        "yallist": "^4.0.0"
+        "@isaacs/fs-minipass": "^4.0.0",
+        "chownr": "^3.0.0",
+        "minipass": "^7.1.2",
+        "minizlib": "^3.1.0",
+        "yallist": "^5.0.0"
       },
       "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/tar-stream": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
-      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "bl": "^4.0.3",
-        "end-of-stream": "^1.4.1",
-        "fs-constants": "^1.0.0",
-        "inherits": "^2.0.3",
-        "readable-stream": "^3.1.1"
-      },
-      "engines": {
-        "node": ">=6"
+        "node": ">=18"
       }
     },
     "node_modules/tar/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
+      "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
       "dev": true,
-      "license": "ISC"
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/temp": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/temp/-/temp-0.9.4.tgz",
+      "integrity": "sha512-yYrrsWnrXMcdsnu/7YMYAofM1ktpL5By7vZhf15CrXijWWrEYZks5AXBudalfSWJLlnen/QUJUB5aoB0kqZUGA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "mkdirp": "^0.5.1",
+        "rimraf": "~2.6.2"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
     },
     "node_modules/temp-file": {
       "version": "3.4.0",
@@ -6751,9 +6702,9 @@
       }
     },
     "node_modules/temp-file/node_modules/jsonfile": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
-      "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6794,6 +6745,26 @@
       },
       "engines": {
         "node": ">=0.8"
+      }
+    },
+    "node_modules/tiny-async-pool": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/tiny-async-pool/-/tiny-async-pool-1.3.0.tgz",
+      "integrity": "sha512-01EAw5EDrcVrdgyCLgoSPvqznC0sVxDSVeiOz09FUpjh71G79VCqneOr+xvt7T1r76CF6ZZfPjHorN2+d+3mqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^5.5.0"
+      }
+    },
+    "node_modules/tiny-async-pool/node_modules/semver": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver"
       }
     },
     "node_modules/tiny-invariant": {
@@ -6843,7 +6814,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6944,6 +6914,16 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/undici": {
+      "version": "6.25.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.25.0.tgz",
+      "integrity": "sha512-ZgpWDC5gmNiuY9CnLVXEH8rl50xhRCuLNA97fAUnKi8RRuV4E6KG31pDTsLVUKnohJE0I3XDrTeEydAXRw47xg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.17"
       }
     },
     "node_modules/undici-types": {
@@ -7071,7 +7051,6 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",
@@ -7147,41 +7126,22 @@
       }
     },
     "node_modules/which": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
-      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/which/-/which-5.0.0.tgz",
+      "integrity": "sha512-JEdGzHwwkrbWoGOlIHqQ5gtprKGOenpDHpxE9zVR1bWbOtYRyPPHMe9FaP6x61CmNaTThSkb0DAJte5jD+DmzQ==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "isexe": "^2.0.0"
+        "isexe": "^3.1.1"
       },
       "bin": {
-        "node-which": "bin/node-which"
+        "node-which": "bin/which.js"
       },
       "engines": {
-        "node": ">= 8"
+        "node": "^18.17.0 || >=20.5.0"
       }
     },
     "node_modules/wrap-ansi": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
-    "node_modules/wrap-ansi-cjs": {
-      "name": "wrap-ansi",
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
@@ -7273,41 +7233,17 @@
         "fd-slicer": "~1.1.0"
       }
     },
-    "node_modules/zip-stream": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-4.1.1.tgz",
-      "integrity": "sha512-9qv4rlDiopXg4E69k+vMHjNN63YFMe9sZMrdlvKnCjlCRWeCBswPPMPUfx+ipsAWq1LXHe70RcbaHdJJpS6hyQ==",
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "archiver-utils": "^3.0.4",
-        "compress-commons": "^4.1.2",
-        "readable-stream": "^3.6.0"
-      },
       "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/zip-stream/node_modules/archiver-utils": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-3.0.4.tgz",
-      "integrity": "sha512-KVgf4XQVrTjhyWmx6cte4RxonPLR9onExufI1jhvw/MQ4BB6IsZD5gT8Lq+u/+pRkWna/6JoHpiQioaqFP5Rzw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "glob": "^7.2.3",
-        "graceful-fs": "^4.2.0",
-        "lazystream": "^1.0.0",
-        "lodash.defaults": "^4.2.0",
-        "lodash.difference": "^4.5.0",
-        "lodash.flatten": "^4.4.0",
-        "lodash.isplainobject": "^4.0.6",
-        "lodash.union": "^4.6.0",
-        "normalize-path": "^3.0.0",
-        "readable-stream": "^3.6.0"
+        "node": ">=10"
       },
-      "engines": {
-        "node": ">= 10"
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -19,6 +19,9 @@
     "python:bundle": "cd python && pyinstaller --onefile --name openextract-engine main.py"
   },
   "dependencies": {
+    "@fontsource/fraunces": "^5.2.9",
+    "@fontsource/geist": "^5.2.8",
+    "@fontsource/ibm-plex-mono": "^5.2.7",
     "benz-amr-recorder": "^1.1.5",
     "date-fns": "^4.1.0",
     "lucide-react": "^0.577.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -36,6 +36,7 @@ export default function App() {
   const [pendingOpen, setPendingOpen] = useState<PendingOpen | null>(null);
   const [passwordError, setPasswordError] = useState<string | null>(null);
   const [unlocking, setUnlocking] = useState(false);
+  const [openError, setOpenError] = useState<string | null>(null);
 
   const openAndNavigate = useCallback(async (
     udid: string,
@@ -44,6 +45,7 @@ export default function App() {
     session: RecentSession | undefined,
     backupInfo: BackupInfo | undefined,
   ) => {
+    setOpenError(null);
     const result = await backup.openBackup(udid, password, backupDir);
 
     if (result.status === 'password_required') {
@@ -56,6 +58,13 @@ export default function App() {
       setScreen('explore');
       setPendingOpen(null);
       setPasswordError(null);
+      return;
+    }
+
+    if (result.status.startsWith('error:')) {
+      setOpenError(result.status.slice(6));
+    } else {
+      setOpenError(`Could not open backup (status: ${result.status}).`);
     }
   }, [backup]);
 
@@ -89,12 +98,19 @@ export default function App() {
           }}
           onCreateBackup={() => setScreen('create-backup')}
           onBrowseForBackup={async () => {
+            setOpenError(null);
             const path = await window.openextract.selectFolder();
             if (!path) return;
-            const found = await backup.listBackups(path, true);
-            if (found.length >= 1) {
+            try {
+              const found = await backup.listBackups(path, true);
+              if (found.length === 0) {
+                setOpenError(`No iPhone backups found in ${path}. Pick the parent folder that contains a UDID-named subfolder (e.g. MobileSync/Backup).`);
+                return;
+              }
               const b = found[0];
               await openAndNavigate(b.udid, undefined, b.backup_dir, undefined, b);
+            } catch (e: any) {
+              setOpenError(e?.message || 'Failed to read backup folder.');
             }
           }}
         />
@@ -120,6 +136,33 @@ export default function App() {
             return 'open';
           }}
         />
+      )}
+
+      {openError && screen === 'home' && (
+        <div
+          role="alert"
+          className="fixed left-1/2 -translate-x-1/2 bottom-6 z-40 max-w-md w-[90%] px-4 py-3 rounded-xl flex items-start gap-3 text-sm"
+          style={{
+            background: 'var(--bg-surface)',
+            border: '1px solid var(--border-strong)',
+            color: 'var(--text-primary)',
+            boxShadow: '0 10px 28px rgba(30,26,22,0.18)',
+          }}
+        >
+          <span
+            className="flex-shrink-0 w-5 h-5 rounded-full flex items-center justify-center text-white text-xs mt-0.5"
+            style={{ background: 'var(--error)' }}
+          >!</span>
+          <div className="flex-1 min-w-0">
+            <div className="font-medium mb-0.5">Couldn't open backup</div>
+            <div className="text-xs text-text-secondary break-words">{openError}</div>
+          </div>
+          <button
+            onClick={() => setOpenError(null)}
+            className="text-text-tertiary hover:text-text-primary flex-shrink-0"
+            aria-label="Dismiss"
+          >×</button>
+        </div>
       )}
 
       {pendingOpen && (

--- a/src/components/explore/BackupDashboard.tsx
+++ b/src/components/explore/BackupDashboard.tsx
@@ -1,5 +1,6 @@
 import { useBackupStats, type BackupStats } from '../../hooks/useBackupStats';
 import CountUp from '../shared/CountUp';
+import OrganicLoader from '../shared/OrganicLoader';
 import {
   LinesIcon, CameraIcon, ContactIcon, CallIcon, NoteIcon, VoicemailIcon,
   LockIcon, ClockIcon,
@@ -58,33 +59,11 @@ function SkeletonPulse({ className = '' }: { className?: string }) {
 
 function LoadingSkeleton() {
   return (
-    <div className="p-6 space-y-6 overflow-y-auto h-full">
-      {/* Hero skeleton */}
-      <div className="rounded-2xl bg-gray-50 border border-gray-200 p-6">
-        <SkeletonPulse className="h-7 w-64 mb-2" />
-        <SkeletonPulse className="h-4 w-96" />
+    <div className="h-full flex flex-col items-center justify-center gap-4 bg-base">
+      <div className="text-accent">
+        <OrganicLoader size={120} />
       </div>
-      {/* Cards skeleton */}
-      <div className="grid grid-cols-3 lg:grid-cols-6 gap-3">
-        {Array.from({ length: 6 }).map((_, i) => (
-          <div key={i} className="rounded-xl bg-white border border-gray-200 p-4">
-            <SkeletonPulse className="h-4 w-4 mb-3" />
-            <SkeletonPulse className="h-8 w-20 mb-1" />
-            <SkeletonPulse className="h-3 w-16" />
-          </div>
-        ))}
-      </div>
-      {/* Insights skeleton */}
-      <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
-        {Array.from({ length: 4 }).map((_, i) => (
-          <div key={i} className="rounded-xl bg-white border border-gray-200 p-5">
-            <SkeletonPulse className="h-5 w-32 mb-4" />
-            <SkeletonPulse className="h-4 w-full mb-2" />
-            <SkeletonPulse className="h-4 w-3/4 mb-2" />
-            <SkeletonPulse className="h-4 w-1/2" />
-          </div>
-        ))}
-      </div>
+      <div className="hearth-eyebrow">Reading your backup</div>
     </div>
   );
 }
@@ -135,13 +114,13 @@ function StatCard({
   return (
     <button
       onClick={onClick}
-      className="rounded-xl bg-white border border-gray-200 p-4 text-left hover:shadow-md hover:border-gray-300 transition-all duration-200 group"
+      className="hearth-card p-4 text-left hover:border-[var(--border-strong)] transition-all duration-200 group"
     >
-      <Icon className="text-gray-400 group-hover:text-emerald-500 transition-colors" size={18} />
-      <div className="mt-2 text-2xl font-semibold text-gray-900 tabular-nums">
+      <Icon className="text-text-tertiary group-hover:text-accent transition-colors" size={18} />
+      <div className="mt-2 text-2xl text-text-primary tabular-nums" style={{ fontFamily: 'Fraunces, serif', fontWeight: 500, letterSpacing: '-0.02em' }}>
         <CountUp end={value} />
       </div>
-      <div className="text-xs text-gray-500 mt-0.5">{label}</div>
+      <div className="text-xs text-text-secondary mt-0.5">{label}</div>
     </button>
   );
 }
@@ -198,29 +177,28 @@ function DashboardContent({ stats, onNavigate }: { stats: BackupStats; onNavigat
   };
 
   return (
-    <div className="p-6 space-y-5 overflow-y-auto h-full">
-      {/* Hero Banner */}
-      <div className="rounded-2xl bg-gradient-to-br from-gray-50 via-white to-emerald-50/30 border border-gray-200 px-6 py-5">
-        <h1 className="text-xl font-semibold text-gray-900">
+    <div className="p-7 space-y-6 overflow-y-auto h-full">
+      {/* Hero */}
+      <div>
+        <div className="hearth-eyebrow mb-2">Overview</div>
+        <h1 className="text-4xl text-text-primary">
           {overview.device_name}
         </h1>
-        <div className="flex items-center gap-3 mt-1.5 text-sm text-gray-500 flex-wrap">
+        <div className="flex items-center gap-3 mt-3 text-sm text-text-secondary flex-wrap">
           {overview.ios_version && (
-            <span className="inline-flex items-center gap-1 bg-gray-100 text-gray-600 px-2 py-0.5 rounded-md text-xs font-medium">
-              iOS {overview.ios_version}
-            </span>
+            <span className="hearth-pill">iOS {overview.ios_version}</span>
           )}
           {overview.last_backup && (
-            <span className="flex items-center gap-1">
-              <ClockIcon size={12} className="text-gray-400" />
+            <span className="flex items-center gap-1.5 font-mono text-xs">
+              <ClockIcon size={12} className="text-text-tertiary" />
               {formatFullDate(overview.last_backup)}
             </span>
           )}
           {overview.size_gb > 0 && (
-            <span>{overview.size_gb.toFixed(1)} GB</span>
+            <span className="font-mono text-xs">{overview.size_gb.toFixed(1)} GB</span>
           )}
           {overview.encrypted && (
-            <span className="flex items-center gap-1 text-emerald-600">
+            <span className="flex items-center gap-1 text-accent">
               <LockIcon size={12} />
               Encrypted
             </span>

--- a/src/components/explore/BrowserHistoryExplorer.tsx
+++ b/src/components/explore/BrowserHistoryExplorer.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, Component } from 'react';
 import type { ReactNode } from 'react';
 import { saveFolder } from '../../lib/ipc';
 import { ExportIcon } from '../shared/Icons';
+import OrganicLoader from '../shared/OrganicLoader';
 import type { HistoryVisit } from '../../lib/browserHistoryStats';
 import BrowserHistoryOverview from './BrowserHistoryOverview';
 import BrowserHistoryTable from './BrowserHistoryTable';
@@ -141,8 +142,8 @@ export default function BrowserHistoryExplorer({ udid, preloadedVisits, preloade
       {/* Body */}
       <div className="flex-1 overflow-hidden">
         {isLoading ? (
-          <div className="h-full flex items-center justify-center text-sm text-gray-400">
-            Loading browser history…
+          <div className="h-full flex items-center justify-center text-accent">
+            <OrganicLoader size={96} />
           </div>
         ) : (
           <BrowserHistoryErrorBoundary>

--- a/src/components/explore/CallExplorer.tsx
+++ b/src/components/explore/CallExplorer.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react';
 import { sidecarCall, saveFolder } from '../../lib/ipc';
 import { SearchIcon, ExportIcon } from '../shared/Icons';
 import { formatDateTime } from '../../lib/dates';
+import OrganicLoader from '../shared/OrganicLoader';
 
 interface Call {
   call_id: number;
@@ -81,23 +82,28 @@ export default function CallExplorer({ udid }: Props) {
 
   return (
     <div className="h-full flex flex-col">
-      <div className="px-4 py-3 border-b border-gray-200 flex items-center justify-between">
-        <h2 className="text-sm font-medium text-gray-900">
-          Calls {total > 0 && <span className="text-gray-400 font-normal">({total.toLocaleString()})</span>}
-        </h2>
+      <div className="flex items-end justify-between gap-4 bg-base" style={{ padding: '20px 28px 14px', borderBottom: '1px solid var(--border-default)', flexShrink: 0 }}>
+        <div>
+          <div className="hearth-eyebrow mb-1.5">
+            Calls{total > 0 && ` · ${total.toLocaleString()} records`}
+          </div>
+          <h1 className="hearth-title text-3xl">
+            Every call, <span className="font-serif-italic text-accent">inbound and out.</span>
+          </h1>
+        </div>
         <div className="flex items-center gap-2">
           <div className="relative">
-            <SearchIcon className="absolute left-2.5 top-1/2 -translate-y-1/2 text-gray-400" size={14} />
+            <SearchIcon className="absolute left-3 top-1/2 -translate-y-1/2 text-text-tertiary" size={13} />
             <input
               type="text"
               placeholder="Search calls..."
               value={search}
               onChange={(e) => setSearch(e.target.value)}
-              className="pl-8 pr-3 py-1.5 text-sm bg-gray-50 rounded-md border border-gray-200 focus:outline-none focus:border-emerald-400 w-48"
+              className="pl-9 pr-3 py-1.5 text-sm bg-surface rounded-full border border-rule focus:outline-none focus:border-accent w-48"
             />
           </div>
-          <button onClick={handleExport} disabled={exporting} className="p-1.5 rounded-md hover:bg-gray-100 transition-colors" title="Export">
-            <ExportIcon className="text-gray-500" size={16} />
+          <button onClick={handleExport} disabled={exporting} className="hearth-ghost-btn" title="Export">
+            <ExportIcon size={13} /> Export CSV
           </button>
         </div>
       </div>
@@ -139,7 +145,11 @@ export default function CallExplorer({ udid }: Props) {
             ))}
           </tbody>
         </table>
-        {loading && <div className="text-center py-8 text-sm text-gray-400">Loading calls...</div>}
+        {loading && (
+          <div className="flex justify-center py-12 text-accent">
+            <OrganicLoader size={72} />
+          </div>
+        )}
         {!loading && filtered.length === 0 && (
           <div className="text-center py-8 text-sm text-gray-400">
             {error || 'No calls found'}

--- a/src/components/explore/ChatBubble.tsx
+++ b/src/components/explore/ChatBubble.tsx
@@ -60,19 +60,19 @@ function AttachmentItem({ udid, attachment, isMine }: { udid: string; attachment
 
   if (!isImageAttachment(attachment)) {
     return (
-      <div className={`text-xs truncate ${isMine ? 'text-emerald-100' : 'text-gray-400'}`}>
+      <div className={`text-xs truncate ${isMine ? 'text-white/75' : 'text-gray-400'}`}>
         📎 {attachment.transfer_name || attachment.filename}
       </div>
     );
   }
 
   if (loading) {
-    return <div className={`text-xs italic ${isMine ? 'text-emerald-100' : 'text-gray-400'}`}>Loading…</div>;
+    return <div className={`text-xs italic ${isMine ? 'text-white/75' : 'text-gray-400'}`}>Loading…</div>;
   }
 
   if (error || !data) {
     return (
-      <div className={`text-xs italic ${isMine ? 'text-emerald-100' : 'text-gray-400'}`}>
+      <div className={`text-xs italic ${isMine ? 'text-white/75' : 'text-gray-400'}`}>
         {attachment.transfer_name || attachment.filename}
       </div>
     );
@@ -100,17 +100,26 @@ export default function ChatBubble({ message, showSender, udid }: Props) {
           <div className="text-[11px] text-gray-400 mb-0.5 px-3">{message.sender}</div>
         )}
         <div
-          className={`rounded-2xl px-3.5 py-2 ${
+          className={`px-4 py-2.5 ${
             isMine
-              ? 'bg-emerald-500 text-white'
-              : 'bg-gray-100 text-gray-900'
+              ? 'text-white'
+              : 'text-text-primary'
           }`}
+          style={{
+            background: isMine ? 'var(--bubble-me)' : 'var(--bubble-them)',
+            borderRadius: 20,
+            borderBottomRightRadius: isMine ? 6 : 20,
+            borderBottomLeftRadius: isMine ? 20 : 6,
+            boxShadow: isMine
+              ? '0 4px 14px rgba(217,119,87,.2)'
+              : '0 1px 0 rgba(30,26,22,.04)',
+          }}
         >
           {message.text && (
             <p className="text-sm whitespace-pre-wrap break-words">{message.text}</p>
           )}
           {message.link_preview?.url && (
-            <div className={`mt-1.5 text-xs ${isMine ? 'text-emerald-100' : 'text-gray-500'}`}>
+            <div className={`mt-1.5 text-xs ${isMine ? 'text-white/75' : 'text-gray-500'}`}>
               {message.link_preview.title && (
                 <div className="font-medium">{message.link_preview.title}</div>
               )}
@@ -125,7 +134,7 @@ export default function ChatBubble({ message, showSender, udid }: Props) {
             </div>
           )}
           {!message.text && !message.has_attachments && (
-            <p className={`text-xs italic ${isMine ? 'text-emerald-100' : 'text-gray-400'}`}>
+            <p className={`text-xs italic ${isMine ? 'text-white/75' : 'text-gray-400'}`}>
               [{message.message_type}]
             </p>
           )}

--- a/src/components/explore/ContactExplorer.tsx
+++ b/src/components/explore/ContactExplorer.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react';
 import { sidecarCall, saveFolder } from '../../lib/ipc';
 import { SearchIcon, ExportIcon, ContactIcon } from '../shared/Icons';
+import OrganicLoader from '../shared/OrganicLoader';
 
 interface Contact {
   id: number;
@@ -67,28 +68,37 @@ export default function ContactExplorer({ udid }: Props) {
 
   return (
     <div className="h-full flex flex-col">
-      <div className="px-4 py-3 border-b border-gray-200 flex items-center justify-between">
-        <h2 className="text-sm font-medium text-gray-900">
-          Contacts {contacts.length > 0 && <span className="text-gray-400 font-normal">({contacts.length})</span>}
-        </h2>
+      <div className="flex items-end justify-between gap-4 bg-base" style={{ padding: '20px 28px 14px', borderBottom: '1px solid var(--border-default)', flexShrink: 0 }}>
+        <div>
+          <div className="hearth-eyebrow mb-1.5">
+            Contacts{contacts.length > 0 && ` · ${contacts.length} total`}
+          </div>
+          <h1 className="hearth-title text-3xl">
+            The people who <span className="font-serif-italic text-accent">mattered.</span>
+          </h1>
+        </div>
         <div className="flex items-center gap-2">
           <div className="relative">
-            <SearchIcon className="absolute left-2.5 top-1/2 -translate-y-1/2 text-gray-400" size={14} />
+            <SearchIcon className="absolute left-3 top-1/2 -translate-y-1/2 text-text-tertiary" size={13} />
             <input
               type="text"
               placeholder="Search contacts..."
               value={search}
               onChange={(e) => setSearch(e.target.value)}
-              className="pl-8 pr-3 py-1.5 text-sm bg-gray-50 rounded-md border border-gray-200 focus:outline-none focus:border-emerald-400 w-48"
+              className="pl-9 pr-3 py-1.5 text-sm bg-surface rounded-full border border-rule focus:outline-none focus:border-accent w-48"
             />
           </div>
-          <button onClick={exportCSV} className="p-1.5 rounded-md hover:bg-gray-100 transition-colors" title="Export CSV">
-            <ExportIcon className="text-gray-500" size={16} />
+          <button onClick={exportCSV} className="hearth-ghost-btn" title="Export CSV">
+            <ExportIcon size={13} /> Export vCard
           </button>
         </div>
       </div>
       <div className="flex-1 overflow-y-auto p-4">
-        {loading && <div className="text-center py-8 text-sm text-gray-400">Loading contacts...</div>}
+        {loading && (
+          <div className="flex justify-center py-12 text-accent">
+            <OrganicLoader size={72} />
+          </div>
+        )}
         {!loading && filtered.length === 0 && (
           <div className="text-center py-8 text-sm text-gray-400">No contacts found</div>
         )}

--- a/src/components/explore/ExploreLayout.tsx
+++ b/src/components/explore/ExploreLayout.tsx
@@ -27,7 +27,7 @@ interface Props {
 }
 
 const allNavItems: { id: Tab; label: string; icon: typeof LinesIcon; comingSoon?: boolean }[] = [
-  { id: 'dashboard', label: 'Dashboard', icon: ChartIcon },
+  { id: 'dashboard', label: 'Overview', icon: ChartIcon },
   { id: 'timeline', label: 'Timeline', icon: ClockIcon },
   { id: 'messages', label: 'Messages', icon: LinesIcon },
   { id: 'photos', label: 'Photos', icon: CameraIcon },
@@ -35,8 +35,8 @@ const allNavItems: { id: Tab; label: string; icon: typeof LinesIcon; comingSoon?
   { id: 'calls', label: 'Calls', icon: CallIcon },
   { id: 'notes', label: 'Notes', icon: NoteIcon },
   { id: 'voicemail', label: 'Voicemail', icon: VoicemailIcon },
-  { id: 'browser_history', label: 'Browser History', icon: GlobeIcon },
-  { id: 'record_recovery', label: 'Record Recovery', icon: RecoverIcon },
+  { id: 'browser_history', label: 'History', icon: GlobeIcon },
+  { id: 'record_recovery', label: 'Recover', icon: RecoverIcon },
   { id: 'export', label: 'Export', icon: ExportIcon },
 ];
 
@@ -68,81 +68,111 @@ export default function ExploreLayout({ udid, session, onBack }: Props) {
     item.id !== 'browser_history' || hasBrowserHistory
   );
 
+  const initial = (session?.name ?? 'B')[0]?.toUpperCase() ?? 'B';
+
   return (
     <div className="h-screen flex bg-base">
-      {/* Sidebar */}
-      <div className="w-[200px] flex-shrink-0 border-r border-border-default flex flex-col">
-        {/* Session info */}
-        <div className="px-4 py-3 border-b border-border-default">
-          <div className="text-sm font-medium text-text-primary truncate">
-            {session?.name || 'Backup'}
+      {/* Chrome header (mac traffic lights + device pill) */}
+      <div className="flex flex-col flex-1 min-w-0">
+        <div className="h-11 flex items-center px-4 border-b border-rule bg-base flex-shrink-0">
+          <div className="flex gap-[7px]">
+            <span className="w-3 h-3 rounded-full" style={{ background: '#ff5f57' }} />
+            <span className="w-3 h-3 rounded-full" style={{ background: '#febc2e' }} />
+            <span className="w-3 h-3 rounded-full" style={{ background: '#28c840' }} />
           </div>
-          {session?.iosVersion && (
-            <div className="text-xs text-text-tertiary">iOS {session.iosVersion}</div>
+          <div className="ml-4 flex items-baseline gap-2">
+            <div
+              className="w-[18px] h-[18px] rounded-full self-center"
+              style={{
+                background: 'radial-gradient(circle at 35% 35%, var(--cream), var(--accent) 80%)',
+              }}
+            />
+            <span className="font-serif text-[16px] font-medium tracking-tight text-text-primary">
+              OpenExtract
+            </span>
+          </div>
+          <div className="flex-1" />
+          {session && (
+            <div className="hearth-pill">
+              <span className="w-[7px] h-[7px] rounded-full" style={{ background: 'var(--sage)' }} />
+              {session.name}
+              {session.iosVersion ? ` · iOS ${session.iosVersion}` : ''}
+            </div>
           )}
         </div>
 
-        {/* Nav items */}
-        <nav className="flex-1 py-2 overflow-y-auto">
-          {navItems.map((item) => {
-            const Icon = item.icon;
-            const isActive = activeTab === item.id;
-            return (
-              <button
-                key={item.id}
-                onClick={() => !item.comingSoon && setActiveTab(item.id)}
-                className={`w-full px-4 py-2 flex items-center gap-2.5 text-left transition-colors ${
-                  isActive
-                    ? 'bg-sidebar-active font-medium border-l-2 border-emerald-500'
-                    : 'hover:bg-surface border-l-2 border-transparent'
-                } ${item.comingSoon ? 'opacity-50 cursor-not-allowed' : ''}`}
-              >
-                <Icon
-                  className={isActive ? 'text-emerald-600' : 'text-text-tertiary'}
-                  size={16}
-                />
-                <span className={`text-sm ${isActive ? 'text-text-primary' : 'text-text-secondary'}`}>
-                  {item.label}
-                </span>
-                {item.comingSoon && (
-                  <span className="text-[10px] bg-elevated text-text-tertiary px-1.5 py-0.5 rounded ml-auto">
-                    Soon
+        <div className="flex flex-1 min-h-0">
+          {/* Hearth icon-rail sidebar */}
+          <nav className="w-[86px] flex-shrink-0 border-r border-rule bg-base py-3.5 px-2 flex flex-col gap-1 items-center">
+            {navItems.map((item) => {
+              const Icon = item.icon;
+              const isActive = activeTab === item.id;
+              return (
+                <button
+                  key={item.id}
+                  title={item.label}
+                  onClick={() => !item.comingSoon && setActiveTab(item.id)}
+                  className={`w-[68px] h-[64px] rounded-[14px] flex flex-col items-center justify-center gap-[3px] transition-all ${
+                    isActive ? 'bg-surface border border-rule' : 'border border-transparent hover:bg-surface/60'
+                  } ${item.comingSoon ? 'opacity-40 cursor-not-allowed' : 'cursor-pointer'}`}
+                  style={
+                    isActive
+                      ? { boxShadow: '0 1px 2px rgba(30,26,22,.06), 0 4px 14px rgba(217,119,87,.10)' }
+                      : undefined
+                  }
+                >
+                  <Icon
+                    size={18}
+                    className={isActive ? 'text-accent' : 'text-text-secondary'}
+                  />
+                  <span
+                    className={`text-[10px] ${isActive ? 'text-accent font-medium' : 'text-text-secondary'}`}
+                  >
+                    {item.label}
                   </span>
-                )}
-              </button>
-            );
-          })}
-        </nav>
+                </button>
+              );
+            })}
+            <div className="flex-1" />
+            {/* Back home */}
+            <button
+              onClick={onBack}
+              title="Home"
+              className="w-[68px] h-[44px] rounded-[12px] flex items-center justify-center text-text-secondary hover:bg-surface transition-colors border border-transparent"
+            >
+              <ArrowLeftIcon size={15} />
+            </button>
+            {/* Session avatar */}
+            <div
+              className="w-9 h-9 rounded-full flex items-center justify-center border border-rule font-serif text-[15px]"
+              style={{ background: 'oklch(82% 0.07 14)', color: '#fff' }}
+              title={session?.name ?? 'Backup'}
+            >
+              {initial}
+            </div>
+          </nav>
 
-        {/* Back link */}
-        <button
-          onClick={onBack}
-          className="px-4 py-3 flex items-center gap-2 text-sm text-text-secondary hover:text-text-primary hover:bg-surface transition-colors border-t border-border-default"
-        >
-          <ArrowLeftIcon size={14} />
-          Home
-        </button>
-      </div>
-
-      {/* Content area */}
-      <div className="flex-1 overflow-hidden">
-        {activeTab === 'dashboard' && <BackupDashboard udid={udid} onNavigate={handleNavigate} />}
-        {activeTab === 'timeline' && <TimelineView udid={udid} />}
-        {activeTab === 'messages' && <MessageExplorer udid={udid} />}
-        {activeTab === 'photos' && <PhotoExplorer udid={udid} />}
-        {activeTab === 'contacts' && <ContactExplorer udid={udid} />}
-        {activeTab === 'calls' && <CallExplorer udid={udid} />}
-        {activeTab === 'notes' && <NoteExplorer udid={udid} />}
-        {activeTab === 'voicemail' && <VoicemailExplorer udid={udid} />}
-        {activeTab === 'browser_history' && (
-          <BrowserHistoryExplorer
-            udid={udid}
-            preloadedVisits={preloadedBrowserHistory}
-            preloadedLoading={browserHistoryPreloading}
-          />
-        )}
-        {activeTab === 'record_recovery' && <RecordRecoveryView udid={udid} />}
-        {activeTab === 'export' && <ExportPanel udid={udid} />}
+          {/* Content area */}
+          <div className="flex-1 overflow-hidden min-w-0">
+            {activeTab === 'dashboard' && <BackupDashboard udid={udid} onNavigate={handleNavigate} />}
+            {activeTab === 'timeline' && <TimelineView udid={udid} />}
+            {activeTab === 'messages' && <MessageExplorer udid={udid} />}
+            {activeTab === 'photos' && <PhotoExplorer udid={udid} />}
+            {activeTab === 'contacts' && <ContactExplorer udid={udid} />}
+            {activeTab === 'calls' && <CallExplorer udid={udid} />}
+            {activeTab === 'notes' && <NoteExplorer udid={udid} />}
+            {activeTab === 'voicemail' && <VoicemailExplorer udid={udid} />}
+            {activeTab === 'browser_history' && (
+              <BrowserHistoryExplorer
+                udid={udid}
+                preloadedVisits={preloadedBrowserHistory}
+                preloadedLoading={browserHistoryPreloading}
+              />
+            )}
+            {activeTab === 'record_recovery' && <RecordRecoveryView udid={udid} />}
+            {activeTab === 'export' && <ExportPanel udid={udid} />}
+          </div>
+        </div>
       </div>
     </div>
   );

--- a/src/components/explore/MessageExplorer.tsx
+++ b/src/components/explore/MessageExplorer.tsx
@@ -401,12 +401,18 @@ export default function MessageExplorer({ udid }: Props) {
         {activeConvo ? (
           <>
             {/* Chat header */}
-            <div className="px-4 py-3 border-b border-gray-200 flex items-center gap-3">
+            <div className="px-5 py-4 border-b border-rule flex items-center gap-3 bg-base">
+              <div
+                className="w-10 h-10 rounded-full flex items-center justify-center text-white font-serif text-lg flex-shrink-0"
+                style={{ background: `radial-gradient(circle at 35% 30%, oklch(85% 0.09 14), oklch(70% 0.10 14))` }}
+              >
+                {(activeConvo.display_name || activeConvo.chat_identifier || '?')[0]?.toUpperCase()}
+              </div>
               <div className="flex-1 min-w-0 overflow-hidden">
-                <div className="text-sm font-medium text-gray-900 truncate">
+                <div className="font-serif text-xl font-medium text-text-primary truncate tracking-tight">
                   {activeConvo.display_name || activeConvo.chat_identifier}
                 </div>
-                <div className="text-xs text-gray-400 truncate">
+                <div className="text-xs text-text-secondary truncate mt-0.5">
                   {totalMessages.toLocaleString()} messages
                   {activeConvo.is_group && ' · Group'}
                 </div>

--- a/src/components/explore/NoteExplorer.tsx
+++ b/src/components/explore/NoteExplorer.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react';
 import { sidecarCall, saveFolder } from '../../lib/ipc';
 import { SearchIcon, ExportIcon } from '../shared/Icons';
+import OrganicLoader from '../shared/OrganicLoader';
 import { formatDate } from '../../lib/dates';
 
 interface Note {
@@ -75,7 +76,11 @@ export default function NoteExplorer({ udid }: Props) {
           </div>
         </div>
         <div className="flex-1 overflow-y-auto">
-          {loading && <div className="text-center py-4 text-sm text-gray-400">Loading...</div>}
+          {loading && (
+            <div className="flex justify-center py-8 text-accent">
+              <OrganicLoader size={56} />
+            </div>
+          )}
           {filtered.map((note) => (
             <button
               key={note.note_id}
@@ -99,18 +104,30 @@ export default function NoteExplorer({ udid }: Props) {
       <div className="flex-1 flex flex-col">
         {selected ? (
           <>
-            <div className="px-4 py-3 border-b border-gray-200 flex items-center justify-between">
+            <div className="px-7 py-5 border-b border-rule flex items-end justify-between bg-base">
               <div>
-                <div className="text-sm font-medium text-gray-900">{selected.title || 'Untitled'}</div>
-                <div className="text-xs text-gray-400">Modified {formatDate(selected.modified)}</div>
+                <div className="hearth-eyebrow mb-1.5">
+                  {formatDate(selected.modified)}
+                </div>
+                <div className="font-serif text-2xl text-text-primary" style={{ fontWeight: 500, letterSpacing: '-0.02em' }}>
+                  {selected.title || 'Untitled'}
+                </div>
               </div>
-              <div className="flex items-center gap-1">
-                <button onClick={() => handleExport('txt')} className="text-xs text-gray-500 hover:text-gray-700 px-2 py-1 rounded hover:bg-gray-100">TXT</button>
-                <button onClick={() => handleExport('pdf')} className="text-xs text-gray-500 hover:text-gray-700 px-2 py-1 rounded hover:bg-gray-100">PDF</button>
+              <div className="flex items-center gap-2">
+                <button onClick={() => handleExport('txt')} className="hearth-ghost-btn">TXT</button>
+                <button onClick={() => handleExport('pdf')} className="hearth-ghost-btn">PDF</button>
               </div>
             </div>
-            <div className="flex-1 overflow-y-auto p-6">
-              <div className="max-w-2xl text-sm text-gray-700 whitespace-pre-wrap leading-relaxed">
+            <div className="flex-1 overflow-y-auto px-10 py-8">
+              <div
+                className="whitespace-pre-wrap text-text-primary"
+                style={{
+                  fontFamily: 'Fraunces, Newsreader, Georgia, serif',
+                  fontSize: 16,
+                  lineHeight: 1.7,
+                  maxWidth: 680,
+                }}
+              >
                 {selected.body}
               </div>
             </div>

--- a/src/components/explore/PhotoExplorer.tsx
+++ b/src/components/explore/PhotoExplorer.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
 import { sidecarCall, saveFolder } from '../../lib/ipc';
 import { SearchIcon, ExportIcon } from '../shared/Icons';
+import OrganicLoader from '../shared/OrganicLoader';
 
 interface PhotoAsset {
   uuid: string;
@@ -235,16 +236,21 @@ export default function PhotoExplorer({ udid }: Props) {
 
   return (
     <div className="h-full flex flex-col">
-      {/* Header */}
-      <div className="px-4 py-3 border-b border-gray-200 flex items-center justify-between">
-        <div className="flex items-center gap-3">
-          <h2 className="text-sm font-medium text-gray-900">
-            Photos {total > 0 && <span className="text-gray-400 font-normal">({total.toLocaleString()})</span>}
-          </h2>
+      {/* Hearth header */}
+      <div className="flex items-end justify-between gap-4 bg-base" style={{ padding: '20px 28px 14px', borderBottom: '1px solid var(--border-default)', flexShrink: 0 }}>
+        <div className="min-w-0 flex-1">
+          <div className="hearth-eyebrow mb-1.5">
+            Photos{total > 0 && ` · ${total.toLocaleString()} recovered`}
+          </div>
+          <h1 className="hearth-title text-3xl">
+            Albums <span className="font-serif-italic text-accent">across the years.</span>
+          </h1>
+        </div>
+        <div className="flex items-center gap-2">
           <select
             value={kindFilter}
             onChange={(e) => setKindFilter(e.target.value)}
-            className="text-xs bg-gray-50 border border-gray-200 rounded px-2 py-1"
+            className="text-xs bg-surface border border-rule rounded-full px-3 py-1.5"
           >
             <option value="all">All types</option>
             <option value="photo">Photos</option>
@@ -252,24 +258,19 @@ export default function PhotoExplorer({ udid }: Props) {
             <option value="live_photo">Live Photos</option>
             <option value="screenshot">Screenshots</option>
           </select>
-        </div>
-        <div className="flex items-center gap-2">
           <div className="relative">
-            <SearchIcon className="absolute left-2.5 top-1/2 -translate-y-1/2 text-gray-400" size={14} />
+            <SearchIcon className="absolute left-3 top-1/2 -translate-y-1/2 text-text-tertiary" size={13} />
             <input
               type="text"
               placeholder="Search photos..."
               value={search}
               onChange={(e) => setSearch(e.target.value)}
-              className="pl-8 pr-3 py-1.5 text-sm bg-gray-50 rounded-md border border-gray-200 focus:outline-none focus:border-emerald-400 w-40"
+              className="pl-9 pr-3 py-1.5 text-sm bg-surface rounded-full border border-rule focus:outline-none focus:border-accent w-40"
             />
           </div>
-          <button
-            onClick={handleExport}
-            disabled={exporting}
-            className="p-1.5 rounded-md hover:bg-gray-100 transition-colors"
-          >
-            <ExportIcon className="text-gray-500" size={16} />
+          <button onClick={handleExport} disabled={exporting} className="hearth-ghost-btn">
+            <ExportIcon size={13} />
+            Export
           </button>
         </div>
       </div>
@@ -355,7 +356,9 @@ export default function PhotoExplorer({ udid }: Props) {
             })}
           </div>
           {loading && (
-            <div className="text-center py-4 text-sm text-gray-400">Loading...</div>
+            <div className="flex justify-center py-8 text-accent">
+              <OrganicLoader size={56} />
+            </div>
           )}
           {!loading && filteredPhotos.length === 0 && (
             <div className="text-center py-8 text-sm text-gray-400">No photos found</div>

--- a/src/components/explore/VoicemailExplorer.tsx
+++ b/src/components/explore/VoicemailExplorer.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useRef } from 'react';
 import BenzAMRRecorder from 'benz-amr-recorder';
 import { saveFolder } from '../../lib/ipc';
 import { ExportIcon } from '../shared/Icons';
+import OrganicLoader from '../shared/OrganicLoader';
 import { formatDateTime, formatDuration } from '../../lib/dates';
 
 interface Voicemail {
@@ -165,16 +166,26 @@ export default function VoicemailExplorer({ udid }: Props) {
 
   return (
     <div className="h-full flex flex-col">
-      <div className="px-4 py-3 border-b border-gray-200 flex items-center justify-between">
-        <h2 className="text-sm font-medium text-gray-900">
-          Voicemail {voicemails.length > 0 && <span className="text-gray-400 font-normal">({voicemails.length})</span>}
-        </h2>
-        <button onClick={handleExport} disabled={exporting} className="p-1.5 rounded-md hover:bg-gray-100 transition-colors" title="Export all">
-          <ExportIcon className="text-gray-500" size={16} />
+      <div className="flex items-end justify-between gap-4 bg-base" style={{ padding: '20px 28px 14px', borderBottom: '1px solid var(--border-default)', flexShrink: 0 }}>
+        <div>
+          <div className="hearth-eyebrow mb-1.5">
+            Voicemail{voicemails.length > 0 && ` · ${voicemails.length}`}
+          </div>
+          <h1 className="hearth-title text-3xl">
+            Voices you <span className="font-serif-italic text-accent">saved.</span>
+          </h1>
+        </div>
+        <button onClick={handleExport} disabled={exporting} className="hearth-ghost-btn" title="Export all">
+          <ExportIcon size={13} />
+          Export audio
         </button>
       </div>
       <div className="flex-1 overflow-y-auto">
-        {loading && <div className="text-center py-8 text-sm text-gray-400">Loading voicemails...</div>}
+        {loading && (
+          <div className="flex justify-center py-12 text-accent">
+            <OrganicLoader size={72} />
+          </div>
+        )}
         {!loading && voicemails.length === 0 && (
           <div className="text-center py-8 text-sm text-gray-400">No voicemails found</div>
         )}

--- a/src/components/home/FirstVisitView.tsx
+++ b/src/components/home/FirstVisitView.tsx
@@ -10,72 +10,77 @@ interface Props {
 
 export default function FirstVisitView({ onGetMyData, onBrowseForBackup, onFirstAction }: Props) {
   return (
-    <div className="h-screen flex flex-col bg-surface">
+    <div className="h-screen flex flex-col bg-base">
       <AppHeader showSettings={false} />
 
       <div className="flex-1 flex flex-col items-center justify-center px-8">
-        <h1 className="text-2xl font-semibold text-text-primary mb-1 text-center">
-          Your iPhone data, unlocked.
+        <div className="hearth-eyebrow mb-3">Welcome</div>
+        <h1 className="text-5xl text-text-primary mb-3 text-center" style={{ maxWidth: 560 }}>
+          Your iPhone data,<br/>
+          <span className="font-serif-italic text-accent">unlocked.</span>
         </h1>
-        <p className="text-sm text-text-tertiary mb-8 text-center">
-          Free. Private. Yours.
+        <p className="text-sm text-text-secondary mb-9 text-center max-w-sm">
+          Free. Private. Yours. Pulled gently from your backup, kept entirely on this computer.
         </p>
 
-        {/* Primary CTA */}
+        {/* Primary CTA — terracotta */}
         <button
           onClick={() => { onFirstAction(); onGetMyData(); }}
-          className="w-full max-w-sm bg-teal-600 hover:bg-teal-700 text-white rounded-xl px-6 py-4 flex items-center gap-4 mb-3 transition-colors text-left shadow-sm"
+          className="w-full max-w-sm text-white rounded-2xl px-6 py-4 flex items-center gap-4 mb-3 transition-colors text-left"
+          style={{
+            background: 'var(--accent)',
+            boxShadow: '0 10px 28px rgba(217,119,87,0.28)',
+          }}
         >
-          <div className="w-9 h-9 rounded-lg bg-teal-500 flex items-center justify-center flex-shrink-0">
+          <div className="w-10 h-10 rounded-xl bg-white/15 flex items-center justify-center flex-shrink-0">
             <PhoneIcon className="text-white" size={20} />
           </div>
           <div className="flex-1">
             <div className="text-base font-medium">Get my data</div>
-            <div className="text-xs text-teal-200">Explore your iPhone</div>
+            <div className="text-xs text-white/70">Explore your iPhone</div>
           </div>
-          <ChevronRightIcon className="text-teal-300 flex-shrink-0" size={20} />
+          <ChevronRightIcon className="text-white/70 flex-shrink-0" size={20} />
         </button>
 
-        {/* Secondary CTA */}
+        {/* Secondary CTA — white card */}
         <button
           onClick={() => { onFirstAction(); onBrowseForBackup(); }}
-          className="w-full max-w-sm bg-base hover:bg-surface rounded-xl px-6 py-4 flex items-center gap-4 mb-8 transition-colors text-left border border-border-default shadow-sm"
+          className="w-full max-w-sm hearth-card hover:bg-[var(--bg-elevated)] px-6 py-4 flex items-center gap-4 mb-9 transition-colors text-left"
         >
-          <div className="w-9 h-9 rounded-lg bg-elevated flex items-center justify-center flex-shrink-0">
+          <div className="w-10 h-10 rounded-xl bg-sand flex items-center justify-center flex-shrink-0">
             <SearchIcon className="text-text-secondary" size={20} />
           </div>
           <div className="flex-1">
-            <div className="text-sm font-medium text-text-secondary">Explore my Data</div>
+            <div className="text-sm font-medium text-text-primary">Explore my data</div>
             <div className="text-xs text-text-tertiary">Open an existing backup folder</div>
           </div>
           <ChevronRightIcon className="text-text-tertiary flex-shrink-0" size={20} />
         </button>
 
         {/* Value props */}
-        <div className="flex items-start gap-8 max-w-sm w-full mb-4">
+        <div className="flex items-start gap-8 max-w-md w-full mb-4">
           <div className="flex-1 text-center">
-            <div className="text-xs font-semibold text-text-secondary mb-0.5">Search everything</div>
-            <div className="text-[11px] text-text-tertiary leading-snug">
+            <div className="text-sm font-medium text-text-primary mb-1">Search everything</div>
+            <div className="text-[11.5px] text-text-tertiary leading-snug">
               Messages, contacts, notes, photos — all in one place
             </div>
           </div>
           <div className="flex-1 text-center">
-            <div className="text-xs font-semibold text-text-secondary mb-0.5">See the big picture</div>
-            <div className="text-[11px] text-text-tertiary leading-snug">
-              Timelines, statistics, and patterns across your history
+            <div className="text-sm font-medium text-text-primary mb-1">See the big picture</div>
+            <div className="text-[11.5px] text-text-tertiary leading-snug">
+              Timelines, statistics, patterns across your history
             </div>
           </div>
           <div className="flex-1 text-center">
-            <div className="text-xs font-semibold text-text-secondary mb-0.5">Export anything</div>
-            <div className="text-[11px] text-text-tertiary leading-snug">
-              PDF reports, spreadsheets, images — your data, your format
+            <div className="text-sm font-medium text-text-primary mb-1">Export anything</div>
+            <div className="text-[11.5px] text-text-tertiary leading-snug">
+              PDF, spreadsheets, images — your data, your format
             </div>
           </div>
         </div>
       </div>
 
-      {/* Footer */}
-      <div className="px-6 py-3 border-t border-border-default bg-base">
+      <div className="px-6 py-3 border-t border-rule bg-base">
         <PrivacyFooter variant="minimal" />
       </div>
     </div>

--- a/src/components/home/ReturnedView.tsx
+++ b/src/components/home/ReturnedView.tsx
@@ -12,39 +12,41 @@ export default function ReturnedView({ onGetMyData, onBrowseForBackup }: Props) 
     <div className="h-screen flex flex-col bg-base">
       <AppHeader />
 
-      <div className="flex-1 overflow-y-auto px-7 py-8">
-        {/* Hero */}
-        <div className="mb-7">
-          <h1 className="text-xl font-medium text-text-primary mb-2">
-            Welcome back. Ready to get your data?
-          </h1>
-          <p className="text-sm text-text-secondary max-w-lg leading-relaxed">
-            Once your iPhone is backed up, you'll be able to search every message, browse every
-            photo, and explore your entire digital history — all privately on your machine.
-          </p>
-        </div>
+      <div className="flex-1 overflow-y-auto px-7 py-8 max-w-2xl mx-auto w-full">
+        <div className="hearth-eyebrow mb-2">Welcome back</div>
+        <h1 className="text-4xl text-text-primary mb-3">
+          Ready to <span className="font-serif-italic text-accent">get your data</span>?
+        </h1>
+        <p className="text-sm text-text-secondary mb-8 max-w-lg leading-relaxed">
+          Once your iPhone is backed up, we'll gently pull out every message, photo, and voicemail —
+          all privately on this machine.
+        </p>
 
-        {/* Primary action card */}
+        {/* Primary action card — terracotta */}
         <button
           onClick={onGetMyData}
-          className="w-full bg-surface rounded-xl p-5 flex items-center gap-4 mb-5 border border-transparent hover:border-border-strong transition-colors text-left"
+          className="w-full text-white rounded-2xl p-5 flex items-center gap-4 mb-3 text-left"
+          style={{
+            background: 'var(--accent)',
+            boxShadow: '0 10px 28px rgba(217,119,87,0.25)',
+          }}
         >
-          <div className="w-10 h-10 rounded-lg bg-gradient-to-br from-emerald-500 to-emerald-400 flex items-center justify-center flex-shrink-0">
+          <div className="w-10 h-10 rounded-xl bg-white/15 flex items-center justify-center flex-shrink-0">
             <DownloadIcon className="text-white" size={20} />
           </div>
           <div className="flex-1 min-w-0">
-            <div className="text-base font-medium text-text-primary">Get my data</div>
-            <div className="text-sm text-text-secondary">Connect your iPhone to start — takes about 30 minutes</div>
+            <div className="text-base font-medium">Get my data</div>
+            <div className="text-xs text-white/75">Connect your iPhone to start — takes about 30 minutes</div>
           </div>
-          <ChevronRightIcon className="text-text-tertiary flex-shrink-0" size={20} />
+          <ChevronRightIcon className="text-white/75 flex-shrink-0" size={20} />
         </button>
 
-        {/* Secondary action — already have a backup */}
+        {/* Secondary action — sand card */}
         <button
           onClick={onBrowseForBackup}
-          className="w-full bg-base border border-border-default rounded-xl p-4 flex items-center gap-3 mb-7 hover:border-border-strong transition-colors text-left"
+          className="w-full hearth-card p-4 flex items-center gap-3 mb-8 hover:bg-[var(--bg-elevated)] text-left transition-colors"
         >
-          <div className="w-8 h-8 rounded-md bg-elevated flex items-center justify-center flex-shrink-0">
+          <div className="w-9 h-9 rounded-lg bg-sand flex items-center justify-center flex-shrink-0">
             <FolderIcon className="text-text-secondary" size={16} />
           </div>
           <div className="flex-1 min-w-0">
@@ -53,40 +55,24 @@ export default function ReturnedView({ onGetMyData, onBrowseForBackup }: Props) 
           </div>
         </button>
 
-        {/* What you'll unlock grid */}
+        {/* What you'll unlock */}
         <div className="mb-7">
-          <div className="text-xs font-medium text-text-tertiary uppercase tracking-wide mb-3">
-            What you'll unlock
-          </div>
+          <div className="hearth-eyebrow mb-3">What you'll unlock</div>
           <div className="grid grid-cols-2 gap-2.5">
-            <div className="flex items-center gap-2.5 p-2.5 bg-surface rounded-md">
-              <LinesIcon className="text-blue-500 flex-shrink-0" size={16} />
-              <div>
-                <div className="text-sm font-medium text-text-primary">Every message</div>
-                <div className="text-xs text-text-tertiary">Including deleted texts</div>
+            {[
+              { I: LinesIcon, title: 'Every message', sub: 'Including deleted texts' },
+              { I: GridIcon, title: 'All your photos', sub: 'With location and metadata' },
+              { I: ClockIcon, title: 'Your timeline', sub: 'Activity across apps and dates' },
+              { I: PlayIcon, title: 'Export anything', sub: 'PDF, CSV, images — your format' },
+            ].map(({ I, title, sub }) => (
+              <div key={title} className="flex items-center gap-2.5 p-3 hearth-card">
+                <I className="text-accent flex-shrink-0" size={16} />
+                <div>
+                  <div className="text-sm font-medium text-text-primary">{title}</div>
+                  <div className="text-xs text-text-tertiary">{sub}</div>
+                </div>
               </div>
-            </div>
-            <div className="flex items-center gap-2.5 p-2.5 bg-surface rounded-md">
-              <GridIcon className="text-green-500 flex-shrink-0" size={16} />
-              <div>
-                <div className="text-sm font-medium text-text-primary">All your photos</div>
-                <div className="text-xs text-text-tertiary">With location and metadata</div>
-              </div>
-            </div>
-            <div className="flex items-center gap-2.5 p-2.5 bg-surface rounded-md">
-              <ClockIcon className="text-amber-500 flex-shrink-0" size={16} />
-              <div>
-                <div className="text-sm font-medium text-text-primary">Your timeline</div>
-                <div className="text-xs text-text-tertiary">Activity across apps and dates</div>
-              </div>
-            </div>
-            <div className="flex items-center gap-2.5 p-2.5 bg-surface rounded-md">
-              <PlayIcon className="text-red-500 flex-shrink-0" size={16} />
-              <div>
-                <div className="text-sm font-medium text-text-primary">Export anything</div>
-                <div className="text-xs text-text-tertiary">PDF, CSV, images — your format</div>
-              </div>
-            </div>
+            ))}
           </div>
         </div>
 

--- a/src/components/home/WorkspaceView.tsx
+++ b/src/components/home/WorkspaceView.tsx
@@ -19,17 +19,18 @@ export default function WorkspaceView({ data, onOpenSession, onGetMoreData, onBr
 
       <div className="flex-1 overflow-y-auto px-7 py-8">
         {/* Header row */}
-        <div className="flex items-center justify-between mb-5">
-          <h1 className="text-lg font-medium text-text-primary">
-            Your digital life, in your hands.
-          </h1>
-          <button
-            onClick={onGetMoreData}
-            className="bg-gradient-to-r from-emerald-500 to-emerald-400 text-white rounded-lg px-4 py-2.5 flex items-center gap-1.5 text-sm font-medium hover:opacity-90 transition-opacity"
-          >
-            <PlusIcon className="text-white" size={14} />
-            Backup iPhone
-          </button>
+        <div className="mb-6">
+          <div className="hearth-eyebrow mb-2">Your archive</div>
+          <div className="flex items-end justify-between gap-6">
+            <h1 className="text-4xl text-text-primary max-w-xl">
+              Your digital life,<br/>
+              <span className="font-serif-italic text-accent">in your hands.</span>
+            </h1>
+            <button onClick={onGetMoreData} className="hearth-primary-btn">
+              <PlusIcon className="text-white" size={14} />
+              Backup iPhone
+            </button>
+          </div>
         </div>
 
         <RecentSessionList

--- a/src/components/shared/AppHeader.tsx
+++ b/src/components/shared/AppHeader.tsx
@@ -1,4 +1,4 @@
-const APP_VERSION = '0.3.0';
+const APP_VERSION = '0.4.0';
 
 interface Props {
   showVersion?: boolean;
@@ -7,16 +7,19 @@ interface Props {
 
 export default function AppHeader({ showVersion = true, showSettings = true }: Props) {
   return (
-    <div className="px-5 py-3 border-b border-border-default flex items-center justify-between">
-      <div className="flex items-center gap-2.5">
-        <div className="w-7 h-7 rounded-full bg-gradient-to-br from-emerald-500 to-emerald-400 flex items-center justify-center">
-          <span className="text-white text-xs font-medium">OE</span>
-        </div>
-        <span className="font-medium text-[15px] text-text-primary">OpenExtract</span>
+    <div className="px-5 py-3 border-b border-rule flex items-center justify-between bg-base">
+      <div className="flex items-baseline gap-2.5">
+        <div
+          className="w-5 h-5 rounded-full self-center"
+          style={{
+            background: 'radial-gradient(circle at 35% 35%, var(--cream), var(--accent) 80%)',
+          }}
+        />
+        <span className="font-serif text-[17px] font-medium text-text-primary tracking-tight">
+          OpenExtract
+        </span>
         {showVersion && (
-          <span className="text-[11px] text-text-tertiary bg-elevated px-2 py-0.5 rounded">
-            v{APP_VERSION}
-          </span>
+          <span className="text-[11px] font-mono text-text-tertiary">v{APP_VERSION}</span>
         )}
       </div>
       {showSettings && (

--- a/src/components/shared/HearthHeader.tsx
+++ b/src/components/shared/HearthHeader.tsx
@@ -1,0 +1,31 @@
+import { ReactNode } from 'react';
+
+interface Props {
+  eyebrow: string;
+  title: ReactNode;
+  italic?: string;
+  right?: ReactNode;
+}
+
+/**
+ * Hearth section header: mono caption eyebrow + Fraunces serif title with
+ * optional italic terracotta accent word. Used across all Explore screens
+ * to match the Hearth aesthetic.
+ */
+export default function HearthHeader({ eyebrow, title, italic, right }: Props) {
+  return (
+    <div
+      className="flex items-end justify-between gap-4 bg-base"
+      style={{ padding: '20px 28px 14px', borderBottom: '1px solid var(--border-default)', flexShrink: 0 }}
+    >
+      <div className="min-w-0 flex-1">
+        <div className="hearth-eyebrow mb-1.5">{eyebrow}</div>
+        <h1 className="hearth-title text-3xl">
+          {title}
+          {italic && <> <span className="font-serif-italic text-accent">{italic}</span></>}
+        </h1>
+      </div>
+      {right && <div className="flex items-center gap-2">{right}</div>}
+    </div>
+  );
+}

--- a/src/components/shared/LoadingScreen.tsx
+++ b/src/components/shared/LoadingScreen.tsx
@@ -1,12 +1,9 @@
+import OrganicLoader from './OrganicLoader';
+
 export default function LoadingScreen() {
   return (
-    <div className="h-screen flex items-center justify-center bg-white">
-      <div className="flex flex-col items-center gap-3">
-        <div className="w-8 h-8 rounded-full bg-gradient-to-br from-emerald-500 to-emerald-400 flex items-center justify-center animate-pulse">
-          <span className="text-white text-xs font-medium">OE</span>
-        </div>
-        <span className="text-sm text-gray-400">Loading...</span>
-      </div>
+    <div className="h-screen flex items-center justify-center bg-base">
+      <OrganicLoader size={96} className="text-accent" />
     </div>
   );
 }

--- a/src/components/shared/OrganicLoader.tsx
+++ b/src/components/shared/OrganicLoader.tsx
@@ -1,0 +1,269 @@
+import { useRef } from 'react';
+
+/**
+ * Organic, blobby loading indicators — 20 variants, SVG + CSS.
+ * Uses currentColor so the Hearth accent cascades from the parent.
+ *
+ * <OrganicLoader />                     — random variant (stable per mount)
+ * <OrganicLoader variant={5} size={80}/> — specific variant + size
+ */
+
+export type OrganicVariant =
+  | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10
+  | 11 | 12 | 13 | 14 | 15 | 16 | 17 | 18 | 19 | 20;
+
+interface Props {
+  variant?: OrganicVariant | 'random';
+  size?: number;
+  className?: string;
+  style?: React.CSSProperties;
+  /** Override fill/stroke. Defaults to currentColor so Tailwind text-* classes work. */
+  color?: string;
+}
+
+const TOTAL = 20;
+
+function pickVariant(): OrganicVariant {
+  return (Math.floor(Math.random() * TOTAL) + 1) as OrganicVariant;
+}
+
+export default function OrganicLoader({
+  variant = 'random',
+  size = 200,
+  className,
+  style,
+  color = 'currentColor',
+}: Props) {
+  // Pick once per mount, keep stable across re-renders
+  const pickedRef = useRef<OrganicVariant | null>(null);
+  if (pickedRef.current === null) {
+    pickedRef.current = variant === 'random' ? pickVariant() : variant;
+  }
+  const v = pickedRef.current;
+
+  // Always render the inner SVG at 200×200 (matches the coordinate system of
+  // every keyframe) and scale down via CSS. Absolute+translate(-50%,-50%) so
+  // the inner div stays centered even when the outer is smaller than 200px —
+  // grid/flex overflow is not symmetric, but absolute positioning is.
+  const scale = size / 200;
+  const wrapStyle: React.CSSProperties = {
+    width: size,
+    height: size,
+    position: 'relative',
+    color,
+    ...style,
+  };
+  const innerStyle: React.CSSProperties = {
+    width: 200,
+    height: 200,
+    position: 'absolute',
+    top: '50%',
+    left: '50%',
+    transform: `translate(-50%, -50%) scale(${scale})`,
+    transformOrigin: 'center',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+  };
+
+  return (
+    <div className={className} style={wrapStyle} role="status" aria-label="Loading">
+      <OrganicSvgFilters />
+      <div style={innerStyle}>
+        <Loader variant={v} />
+      </div>
+    </div>
+  );
+}
+
+/* SVG filter definitions (goo + goo-soft). Rendered once, lazily. */
+function OrganicSvgFilters() {
+  return (
+    <svg
+      width="0"
+      height="0"
+      style={{ position: 'absolute' }}
+      aria-hidden="true"
+      data-organic-loader-defs
+    >
+      <defs>
+        <filter id="ol-goo">
+          <feGaussianBlur in="SourceGraphic" stdDeviation="6" />
+          <feColorMatrix values="1 0 0 0 0  0 1 0 0 0  0 0 1 0 0  0 0 0 22 -11" />
+        </filter>
+        <filter id="ol-goo-soft">
+          <feGaussianBlur in="SourceGraphic" stdDeviation="4" />
+          <feColorMatrix values="1 0 0 0 0  0 1 0 0 0  0 0 1 0 0  0 0 0 18 -8" />
+        </filter>
+      </defs>
+    </svg>
+  );
+}
+
+function Loader({ variant }: { variant: OrganicVariant }) {
+  // SVG always rendered at 200 user units so pixel-based keyframes work.
+  const svgProps = {
+    viewBox: '0 0 200 200',
+    width: 200,
+    height: 200,
+    style: { overflow: 'visible' as const, display: 'block' },
+  };
+
+  switch (variant) {
+    case 1: return (
+      <div className="ol-l01-wrap" style={{ transformOrigin: '50% 50%' }}>
+        <svg className="ol-l01" {...svgProps}>
+          <g transform="translate(50,50)">
+            <path d="M 50 0 C 78 0 100 22 100 50 C 100 78 78 100 50 100 C 22 100 0 78 0 50 C 0 22 22 0 50 0 Z" fill="currentColor"/>
+          </g>
+        </svg>
+      </div>
+    );
+    case 2: return (
+      <div className="ol-l02-wrap">
+        <svg className="ol-l02" {...svgProps} filter="url(#ol-goo)">
+          <ellipse cx="60"  cy="100" rx="22" ry="28" fill="currentColor"/>
+          <ellipse cx="140" cy="100" rx="30" ry="20" fill="currentColor"/>
+        </svg>
+      </div>
+    );
+    case 3: return (
+      <svg className="ol-l03" {...svgProps} filter="url(#ol-goo)">
+        <circle r="10" fill="currentColor"/>
+        <circle r="14" fill="currentColor"/>
+        <circle r="10" fill="currentColor"/>
+      </svg>
+    );
+    case 4: return (
+      <div className="ol-l04-wrap">
+        <svg className="ol-l04" {...svgProps}>
+          <path d="M 100 25 C 140 25 175 60 175 100 C 175 140 140 175 100 175 C 60 175 25 140 25 100 C 25 60 60 25 100 25 Z"
+                fill="none" stroke="currentColor" strokeWidth="10" strokeLinecap="round"/>
+        </svg>
+      </div>
+    );
+    case 5: return (
+      <div className="ol-l05-wrap">
+        <svg {...svgProps}>
+          <ellipse cx="100" cy="100" rx="34" ry="34" fill="currentColor"/>
+        </svg>
+      </div>
+    );
+    case 6: return (
+      <div className="ol-l06-wrap">
+        <svg {...svgProps} filter="url(#ol-goo)">
+          <circle cx="100" cy="40" r="16" fill="currentColor"/>
+          <circle cx="100" cy="62" r="12" fill="currentColor"/>
+          <circle cx="100" cy="80" r="8"  fill="currentColor"/>
+          <circle cx="100" cy="94" r="5"  fill="currentColor"/>
+        </svg>
+      </div>
+    );
+    case 7: return (
+      <svg className="ol-l07" {...svgProps} filter="url(#ol-goo)">
+        <ellipse className="a" cx="100" cy="100" rx="26" ry="26" fill="currentColor"/>
+        <ellipse className="b" cx="100" cy="100" rx="26" ry="26" fill="currentColor"/>
+      </svg>
+    );
+    case 8: return (
+      <svg className="ol-l08" {...svgProps}>
+        <circle cx="100" cy="100" r="10" fill="none" stroke="currentColor" strokeWidth="3"/>
+        <circle cx="100" cy="100" r="10" fill="none" stroke="currentColor" strokeWidth="3"/>
+        <circle cx="100" cy="100" r="10" fill="none" stroke="currentColor" strokeWidth="3"/>
+        <path className="core" d="M 100 70 C 120 70 130 85 130 100 C 130 115 115 130 100 130 C 85 130 70 115 70 100 C 70 85 80 70 100 70 Z" fill="currentColor"/>
+      </svg>
+    );
+    case 9: return (
+      <svg className="ol-l09" {...svgProps}>
+        <path d="M 100 40 C 130 40 150 60 150 90 C 150 130 125 160 100 160 C 75 160 50 130 50 90 C 50 60 70 40 100 40 Z" fill="currentColor"/>
+      </svg>
+    );
+    case 10: return (
+      <div className="ol-l10-wrap">
+        <svg className="ol-l10" {...svgProps}>
+          <path d="M 100 30 Q 140 60 170 100 Q 140 140 100 170 Q 60 140 30 100 Q 60 60 100 30 Z" fill="currentColor"/>
+        </svg>
+      </div>
+    );
+    case 11: return (
+      <div className="ol-l11-wrap">
+        <svg className="ol-l11" {...svgProps}>
+          <path d="M 100 40 C 140 40 150 70 140 100 C 130 130 120 150 100 160 C 80 150 70 130 60 100 C 50 70 60 40 100 40 Z" fill="currentColor"/>
+        </svg>
+      </div>
+    );
+    case 12: return (
+      <div className="ol-l12-wrap">
+        <svg className="ol-l12" {...svgProps} filter="url(#ol-goo)">
+          <circle cx="85"  cy="85"  r="20" fill="currentColor"/>
+          <circle cx="115" cy="85"  r="22" fill="currentColor"/>
+          <circle cx="85"  cy="115" r="22" fill="currentColor"/>
+          <circle cx="115" cy="115" r="20" fill="currentColor"/>
+        </svg>
+      </div>
+    );
+    case 13: return (
+      <div className="ol-l13-wrap" style={{ display: 'grid', placeItems: 'center' }}>
+        <svg className="ol-l13" viewBox="-50 -50 100 100" width={200} height={200} style={{ overflow: 'visible', display: 'block' }}>
+          <path d="M 0 -35 C 25 -35 40 -20 38 5 C 35 30 15 38 -5 36 C -30 32 -40 12 -36 -10 C -32 -28 -20 -38 0 -35 Z" fill="currentColor"/>
+        </svg>
+      </div>
+    );
+    case 14: return (
+      <svg className="ol-l14" {...svgProps}>
+        <path d="M 50 100 C 50 70 80 70 100 100 C 120 130 150 130 150 100 C 150 70 120 70 100 100 C 80 130 50 130 50 100 Z"
+              fill="none" stroke="currentColor" strokeWidth="10" strokeLinecap="round"/>
+      </svg>
+    );
+    case 15: return (
+      <svg className="ol-l15" {...svgProps} filter="url(#ol-goo)">
+        <path d="M 100 40 C 130 40 150 60 150 90 C 150 120 125 140 100 140 C 75 140 50 120 50 90 C 50 60 70 40 100 40 Z" fill="currentColor"/>
+        <circle cx="100" cy="150" r="6" fill="currentColor"/>
+      </svg>
+    );
+    case 16: return (
+      <svg className="ol-l16" {...svgProps}>
+        <rect x="40"  y="70" width="16" height="60" rx="8" fill="currentColor"/>
+        <rect x="68"  y="70" width="16" height="60" rx="8" fill="currentColor"/>
+        <rect x="96"  y="70" width="16" height="60" rx="8" fill="currentColor"/>
+        <rect x="124" y="70" width="16" height="60" rx="8" fill="currentColor"/>
+        <rect x="152" y="70" width="16" height="60" rx="8" fill="currentColor"/>
+      </svg>
+    );
+    case 17: return (
+      <div className="ol-l17-wrap">
+        <svg className="ol-l17" {...svgProps}>
+          <path d="M 100 40 C 135 40 160 65 160 100 C 160 135 135 160 100 160 C 65 160 40 135 40 100 C 40 65 65 40 100 40 Z"
+                fill="none" stroke="currentColor" strokeWidth="12" strokeLinecap="round" pathLength={200}/>
+        </svg>
+      </div>
+    );
+    case 18: return (
+      <div className="ol-l18-wrap">
+        <svg className="ol-l18" {...svgProps}>
+          <path d="M 60 100 C 60 70 80 50 110 50 C 150 50 160 80 150 110 C 140 140 110 150 90 145 C 65 140 60 125 60 100 Z" fill="currentColor"/>
+        </svg>
+      </div>
+    );
+    case 19: return (
+      <svg className="ol-l19" {...svgProps} filter="url(#ol-goo)">
+        <circle cx="50"  cy="100" r="12" fill="currentColor"/>
+        <circle cx="75"  cy="100" r="14" fill="currentColor"/>
+        <circle cx="100" cy="100" r="15" fill="currentColor"/>
+        <circle cx="125" cy="100" r="14" fill="currentColor"/>
+        <circle cx="150" cy="100" r="12" fill="currentColor"/>
+      </svg>
+    );
+    case 20: return (
+      <svg className="ol-l20" {...svgProps} filter="url(#ol-goo)">
+        <circle className="core" cx="100" cy="100" r="18" fill="currentColor"/>
+        <g className="ol-l20-a">
+          <circle cx="100" cy="50" r="12" fill="currentColor"/>
+        </g>
+        <g className="ol-l20-b">
+          <circle cx="100" cy="150" r="10" fill="currentColor"/>
+        </g>
+      </svg>
+    );
+  }
+}

--- a/src/components/shared/PasswordDialog.tsx
+++ b/src/components/shared/PasswordDialog.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { LockIcon } from './Icons';
+import OrganicLoader from './OrganicLoader';
 
 interface Props {
   deviceName?: string;
@@ -61,9 +62,16 @@ export default function PasswordDialog({ deviceName, error, loading, onSubmit, o
             <button
               type="submit"
               disabled={!password.trim() || loading}
-              className="flex-1 px-4 py-2.5 text-sm text-white bg-emerald-500 rounded-lg hover:bg-emerald-600 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+              className="flex-1 px-4 py-2.5 text-sm text-white bg-accent rounded-lg hover:bg-[var(--accent-hover)] transition-colors disabled:opacity-50 disabled:cursor-not-allowed inline-flex items-center justify-center gap-2"
             >
-              {loading ? 'Unlocking...' : 'Unlock'}
+              {loading ? (
+                <>
+                  <OrganicLoader size={20} color="#fff" />
+                  <span>Unlocking…</span>
+                </>
+              ) : (
+                'Unlock'
+              )}
             </button>
           </div>
         </form>

--- a/src/components/timeline/TimelineView.tsx
+++ b/src/components/timeline/TimelineView.tsx
@@ -7,6 +7,7 @@ import TimelineEntryCard from './TimelineEntryCard';
 import { formatDate } from '../../lib/dates';
 import { saveFolder } from '../../lib/ipc';
 import { formatTimeline, FORMAT_FILTERS, ExportFormat } from '../../lib/timelineExport';
+import OrganicLoader from '../shared/OrganicLoader';
 
 interface Props {
   udid: string;
@@ -101,20 +102,21 @@ export default function TimelineView({ udid }: Props) {
 
       {/* Header */}
       <div style={{
-        display: 'flex', alignItems: 'center', justifyContent: 'space-between',
-        padding: '14px 20px 12px',
-        borderBottom: '0.5px solid var(--border-default)',
+        display: 'flex', alignItems: 'flex-end', justifyContent: 'space-between', gap: 16,
+        padding: '20px 28px 14px',
+        borderBottom: '1px solid var(--border-default)',
         flexShrink: 0,
       }}>
-        <div style={{ display: 'flex', alignItems: 'baseline', gap: 10 }}>
-          <span className="text-title font-semibold">Timeline</span>
-          {!loading && (
-            <span className="text-body text-text-secondary">
-              {totalFiltered.toLocaleString()} event{totalFiltered !== 1 ? 's' : ''}
-            </span>
-          )}
+        <div>
+          <div className="hearth-eyebrow mb-1.5">
+            Timeline
+            {!loading && ` · ${totalFiltered.toLocaleString()} event${totalFiltered !== 1 ? 's' : ''}`}
+          </div>
+          <h1 className="hearth-title text-3xl">
+            Everything, <span className="font-serif-italic text-accent">in order.</span>
+          </h1>
           {loading && (
-            <span style={{ display: 'flex', alignItems: 'center', gap: 4, fontSize: 12, color: 'var(--text-tertiary)' }}>
+            <span style={{ display: 'flex', alignItems: 'center', gap: 4, fontSize: 12, color: 'var(--text-tertiary)', marginTop: 4 }}>
               <Loader2 size={11} className="animate-spin" />
               Loading…
             </span>
@@ -216,7 +218,10 @@ export default function TimelineView({ udid }: Props) {
             padding: '24px 32px',
             minWidth: 280,
           }}>
-            <div style={{ fontSize: 15, fontWeight: 600, marginBottom: 16 }}>Loading Timeline…</div>
+            <div className="flex justify-center mb-3 text-accent">
+              <OrganicLoader size={72} />
+            </div>
+            <div className="hearth-eyebrow text-center mb-4">Loading timeline</div>
             {ALL_TYPES.map(type => {
               const isLoading = loadingTypes.has(type);
               const hasError = !!errors[type];

--- a/src/index.css
+++ b/src/index.css
@@ -2,62 +2,48 @@
 @tailwind components;
 @tailwind utilities;
 
-/* ===== Titanium Design System — Light Mode (Default) ===== */
+/* ===== Hearth Design System ===== */
+/* Warm off-white #fbf6f1, soft terracotta & sage, organic round cards.
+   Fraunces display, Geist body, IBM Plex Mono for captions/times. */
 :root {
-  --bg-base: #ffffff;
-  --bg-surface: #f5f5f7;
-  --bg-elevated: #e8e8ed;
-  --bg-sidebar: rgba(245, 245, 247, 0.85);
-  --bg-sidebar-active: rgba(0, 0, 0, 0.06);
+  --bg-base: #fbf6f1;
+  --bg-surface: #ffffff;
+  --bg-elevated: #f2e9dd; /* sand */
+  --bg-sidebar: #fbf6f1;
+  --bg-sidebar-active: #ffffff;
 
-  --text-primary: #1d1d1f;
-  --text-secondary: #6e6e73;
-  --text-tertiary: #aeaeb2;
-  --text-accent: #0071e3;
+  --text-primary: #1e1a16;
+  --text-secondary: #655a4f;
+  --text-tertiary: #97897a;
+  --text-accent: #d97757;
 
-  --border-subtle: rgba(0, 0, 0, 0.04);
-  --border-default: rgba(0, 0, 0, 0.08);
-  --border-strong: rgba(0, 0, 0, 0.14);
+  --border-subtle: rgba(236, 225, 209, 0.6);
+  --border-default: #ece1d1;
+  --border-strong: #d9c8ad;
 
-  --accent: #0071e3;
-  --accent-hover: #0077ed;
-  --accent-subtle: rgba(0, 113, 227, 0.08);
+  --accent: #d97757;         /* terracotta */
+  --accent-hover: #c26547;
+  --accent-subtle: rgba(217, 119, 87, 0.1);
+  --accent-wash: #f7e6d8;
 
-  --success: #30d158;
-  --warning: #ff9f0a;
-  --error: #ff3b30;
+  --sage: #7a9a7a;
+  --cream: #f0d894;
 
-  color-scheme: light dark;
-}
+  --success: #7a9a7a;
+  --warning: #d4a245;
+  --error: #c85a3a;
 
-/* ===== Titanium Design System — Dark Mode ===== */
-@media (prefers-color-scheme: dark) {
-  :root {
-    --bg-base: #1c1c1e;
-    --bg-surface: #2c2c2e;
-    --bg-elevated: #3a3a3c;
-    --bg-sidebar: rgba(28, 28, 30, 0.85);
-    --bg-sidebar-active: rgba(255, 255, 255, 0.08);
+  /* Messages bubbles */
+  --bubble-me: #d97757;
+  --bubble-them: #f2e9dd;
 
-    --text-primary: #f5f5f7;
-    --text-secondary: #aeaeb2;
-    --text-tertiary: #636366;
-    --text-accent: #0a84ff;
-
-    --border-subtle: rgba(255, 255, 255, 0.04);
-    --border-default: rgba(255, 255, 255, 0.08);
-    --border-strong: rgba(255, 255, 255, 0.14);
-
-    --accent: #0a84ff;
-    --accent-hover: #409cff;
-    --accent-subtle: rgba(10, 132, 255, 0.15);
-  }
+  color-scheme: light;
 }
 
 /* ===== Base Styles ===== */
 body {
   margin: 0;
-  font-family: -apple-system, BlinkMacSystemFont, 'SF Pro Text', 'Segoe UI', system-ui, sans-serif;
+  font-family: 'Geist', -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
   font-size: 13px;
   line-height: 1.5;
   letter-spacing: -0.003em;
@@ -94,4 +80,296 @@ body {
 ::selection {
   background: var(--accent-subtle);
   color: var(--text-primary);
+}
+
+/* ===== Hearth display typography ===== */
+/* Big page titles use Fraunces serif. Small heads stay in Geist.
+   Tailwind's `text-xl` is 20px, `text-2xl` 24px, etc.
+   Classes with text-xl or larger get Fraunces; smaller stay in Geist. */
+.text-xl, .text-2xl, .text-3xl, .text-4xl, .text-5xl, .text-6xl,
+h1.text-lg, h1.text-base, h2.text-lg {
+  font-family: 'Fraunces', 'Newsreader', Georgia, serif;
+  font-weight: 500;
+  letter-spacing: -0.02em;
+  line-height: 1.08;
+}
+/* Italic Fraunces for emphatic words inside serif titles */
+.font-serif-italic {
+  font-family: 'Fraunces', 'Newsreader', Georgia, serif;
+  font-style: italic;
+  font-weight: 400;
+}
+
+/* ===== Hearth component utilities ===== */
+.hearth-eyebrow {
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 10.5px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-tertiary);
+  font-weight: 500;
+}
+
+.hearth-title {
+  font-family: 'Fraunces', 'Newsreader', Georgia, serif;
+  font-weight: 500;
+  letter-spacing: -0.02em;
+  color: var(--text-primary);
+  line-height: 1.05;
+}
+
+.hearth-card {
+  background: var(--bg-surface);
+  border: 1px solid var(--border-default);
+  border-radius: 12px;
+  box-shadow: 0 1px 2px rgba(30, 26, 22, 0.04);
+}
+
+.hearth-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 11px;
+  border-radius: 999px;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-default);
+  font-size: 11.5px;
+  color: var(--text-secondary);
+}
+
+.hearth-ghost-btn {
+  background: transparent;
+  border: 1px solid var(--border-default);
+  color: var(--text-primary);
+  padding: 6px 12px;
+  border-radius: 999px;
+  font-size: 12px;
+  font-family: inherit;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  cursor: pointer;
+  transition: background 0.15s;
+}
+.hearth-ghost-btn:hover {
+  background: var(--bg-elevated);
+}
+
+.hearth-primary-btn {
+  background: var(--accent);
+  color: #fff;
+  border: 0;
+  padding: 7px 14px;
+  border-radius: 999px;
+  font-size: 12px;
+  font-weight: 500;
+  font-family: inherit;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  cursor: pointer;
+  box-shadow: 0 4px 12px rgba(217, 119, 87, 0.22);
+  transition: background 0.15s, box-shadow 0.15s;
+}
+.hearth-primary-btn:hover {
+  background: var(--accent-hover);
+}
+.hearth-primary-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+  box-shadow: none;
+}
+
+/* ===== Organic loaders (20 variants) =====
+   SVG + CSS blob animations. Uses currentColor so Hearth accent cascades. */
+
+/* 01 Breathing blob */
+@keyframes ol-blob-breathe { 0%,100% { transform: scale(1) rotate(0deg); } 50% { transform: scale(1.08) rotate(180deg); } }
+@keyframes ol-blob-morph {
+  0%,100% { d: path("M 50 0 C 78 0 100 22 100 50 C 100 78 78 100 50 100 C 22 100 0 78 0 50 C 0 22 22 0 50 0 Z"); }
+  33%     { d: path("M 50 2 C 82 6 96 28 98 54 C 100 82 74 102 48 98 C 18 94 2 74 4 46 C 6 20 24 -2 50 2 Z"); }
+  66%     { d: path("M 52 4 C 80 0 102 26 96 56 C 92 84 70 98 44 96 C 16 94 -2 70 4 44 C 10 18 28 8 52 4 Z"); }
+}
+.ol-l01-wrap { animation: ol-blob-breathe 3.2s ease-in-out infinite; transform-origin: 50% 50%; }
+.ol-l01 path { animation: ol-blob-morph 3.2s ease-in-out infinite; }
+
+/* 02 Orbiting pair */
+@keyframes ol-l02-spin { to { transform: rotate(360deg); } }
+@keyframes ol-l02-squish-a { 0%,100% { rx: 22; ry: 28; } 50% { rx: 30; ry: 20; } }
+@keyframes ol-l02-squish-b { 0%,100% { rx: 30; ry: 20; } 50% { rx: 22; ry: 28; } }
+.ol-l02-wrap { animation: ol-l02-spin 2s linear infinite; transform-origin: 50% 50%; }
+.ol-l02 ellipse:nth-child(1) { animation: ol-l02-squish-a 1s ease-in-out infinite; }
+.ol-l02 ellipse:nth-child(2) { animation: ol-l02-squish-b 1s ease-in-out infinite; }
+
+/* 03 Three-dot metaball */
+@keyframes ol-l03-pulse-a { 0%,100% { r: 10; transform: translate(60px,100px); } 50% { r: 18; transform: translate(72px,100px); } }
+@keyframes ol-l03-pulse-b { 0%,100% { r: 14; transform: translate(100px,100px); } 50% { r: 8;  transform: translate(100px,100px); } }
+@keyframes ol-l03-pulse-c { 0%,100% { r: 10; transform: translate(140px,100px); } 50% { r: 18; transform: translate(128px,100px); } }
+.ol-l03 circle:nth-child(1) { animation: ol-l03-pulse-a 1.4s ease-in-out infinite; transform-box: fill-box; }
+.ol-l03 circle:nth-child(2) { animation: ol-l03-pulse-b 1.4s ease-in-out infinite; }
+.ol-l03 circle:nth-child(3) { animation: ol-l03-pulse-c 1.4s ease-in-out infinite; transform-box: fill-box; }
+
+/* 04 Wobbling ring */
+@keyframes ol-l04-spin { to { transform: rotate(360deg); } }
+@keyframes ol-l04-wobble {
+  0%,100% { d: path("M 100 25 C 140 25 175 60 175 100 C 175 140 140 175 100 175 C 60 175 25 140 25 100 C 25 60 60 25 100 25 Z"); }
+  50%     { d: path("M 100 28 C 145 24 172 62 172 104 C 176 142 136 178 98 174 C 58 174 28 136 28 96 C 24 58 60 30 100 28 Z"); }
+}
+.ol-l04-wrap { animation: ol-l04-spin 4s linear infinite; transform-origin: 50% 50%; }
+.ol-l04 path { animation: ol-l04-wobble 2s ease-in-out infinite; }
+
+/* 05 Jelly drop */
+@keyframes ol-l05-drop {
+  0%   { transform: translateY(-10px) scale(1,1); }
+  40%  { transform: translateY(40px) scale(1.15,0.85); }
+  60%  { transform: translateY(40px) scale(0.85,1.15); }
+  100% { transform: translateY(-10px) scale(1,1); }
+}
+.ol-l05-wrap { animation: ol-l05-drop 1.6s ease-in-out infinite; transform-origin: 50% 50%; }
+
+/* 06 Tadpole trail */
+@keyframes ol-l06-rotate { to { transform: rotate(360deg); } }
+.ol-l06-wrap { animation: ol-l06-rotate 1.4s linear infinite; transform-origin: 50% 50%; }
+
+/* 07 Amoeba split */
+@keyframes ol-l07-a { 0%,100% { transform: translateX(0); } 50% { transform: translateX(-18px); } }
+@keyframes ol-l07-b { 0%,100% { transform: translateX(0); } 50% { transform: translateX(18px); } }
+@keyframes ol-l07-stretch { 0%,100% { rx: 26; ry: 26; } 50% { rx: 22; ry: 30; } }
+.ol-l07 .a { animation: ol-l07-a 1.8s ease-in-out infinite, ol-l07-stretch 1.8s ease-in-out infinite; transform-origin: center; transform-box: fill-box; }
+.ol-l07 .b { animation: ol-l07-b 1.8s ease-in-out infinite, ol-l07-stretch 1.8s ease-in-out infinite; transform-origin: center; transform-box: fill-box; }
+
+/* 08 Ink ripple */
+@keyframes ol-l08-ripple { 0% { r: 10; opacity: 1; } 100% { r: 80; opacity: 0; } }
+.ol-l08 circle:nth-child(1) { animation: ol-l08-ripple 2s ease-out infinite; }
+.ol-l08 circle:nth-child(2) { animation: ol-l08-ripple 2s ease-out infinite .4s; }
+.ol-l08 circle:nth-child(3) { animation: ol-l08-ripple 2s ease-out infinite .8s; }
+.ol-l08 .core { animation: ol-l09-morph 3s ease-in-out infinite; }
+
+/* 09 Lava blob */
+@keyframes ol-l09-morph {
+  0%,100% { d: path("M 100 40 C 130 40 150 60 150 90 C 150 130 125 160 100 160 C 75 160 50 130 50 90 C 50 60 70 40 100 40 Z"); }
+  50%     { d: path("M 100 42 C 140 46 154 76 144 106 C 138 140 110 162 96 158 C 70 158 46 128 58 94 C 66 66 78 40 100 42 Z"); }
+}
+.ol-l09 path { animation: ol-l09-morph 2.4s ease-in-out infinite; }
+
+/* 10 Four-lobed flower */
+@keyframes ol-l10-spin { to { transform: rotate(360deg); } }
+@keyframes ol-l10-pulse {
+  0%,100% { d: path("M 100 30 Q 140 60 170 100 Q 140 140 100 170 Q 60 140 30 100 Q 60 60 100 30 Z"); }
+  50%     { d: path("M 100 50 Q 150 50 150 100 Q 150 150 100 150 Q 50 150 50 100 Q 50 50 100 50 Z"); }
+}
+.ol-l10-wrap { animation: ol-l10-spin 6s linear infinite; transform-origin: 50% 50%; }
+.ol-l10 path { animation: ol-l10-pulse 2s ease-in-out infinite; }
+
+/* 11 Comma drift */
+@keyframes ol-l11-drift { 0% { transform: rotate(0deg); } 100% { transform: rotate(360deg); } }
+@keyframes ol-l11-wag {
+  0%,100% { d: path("M 100 40 C 140 40 150 70 140 100 C 130 130 120 150 100 160 C 80 150 70 130 60 100 C 50 70 60 40 100 40 Z"); }
+  50%     { d: path("M 100 40 C 145 45 155 75 140 100 C 125 130 125 155 100 160 C 75 155 75 130 60 100 C 45 75 55 35 100 40 Z"); }
+}
+.ol-l11-wrap { animation: ol-l11-drift 2.4s ease-in-out infinite; transform-origin: 50% 50%; }
+.ol-l11 path { animation: ol-l11-wag 1.2s ease-in-out infinite; }
+
+/* 12 Breathing cluster */
+@keyframes ol-l12-a { 0%,100% { transform: translate(0,0); } 50% { transform: translate(6px,-4px); } }
+@keyframes ol-l12-b { 0%,100% { transform: translate(0,0); } 50% { transform: translate(-5px,5px); } }
+@keyframes ol-l12-c { 0%,100% { transform: translate(0,0); } 50% { transform: translate(4px,6px); } }
+@keyframes ol-l12-d { 0%,100% { transform: translate(0,0); } 50% { transform: translate(-6px,-3px); } }
+@keyframes ol-l12-breathe { 0%,100% { transform: scale(1); } 50% { transform: scale(1.06); } }
+.ol-l12-wrap { animation: ol-l12-breathe 2.4s ease-in-out infinite; transform-origin: 50% 50%; }
+.ol-l12 circle:nth-child(1) { animation: ol-l12-a 1.6s ease-in-out infinite; transform-origin: center; transform-box: fill-box; }
+.ol-l12 circle:nth-child(2) { animation: ol-l12-b 1.8s ease-in-out infinite; transform-origin: center; transform-box: fill-box; }
+.ol-l12 circle:nth-child(3) { animation: ol-l12-c 2.0s ease-in-out infinite; transform-origin: center; transform-box: fill-box; }
+.ol-l12 circle:nth-child(4) { animation: ol-l12-d 2.2s ease-in-out infinite; transform-origin: center; transform-box: fill-box; }
+
+/* 13 Rolling pebble */
+@keyframes ol-l13-roll { 0% { transform: translateX(-60px) rotate(0deg); } 100% { transform: translateX(60px) rotate(720deg); } }
+@keyframes ol-l13-wob {
+  0%,100% { d: path("M 0 -35 C 25 -35 40 -20 38 5 C 35 30 15 38 -5 36 C -30 32 -40 12 -36 -10 C -32 -28 -20 -38 0 -35 Z"); }
+  50%     { d: path("M 2 -38 C 30 -32 42 -12 34 10 C 28 34 6 42 -12 34 C -34 24 -42 4 -36 -18 C -30 -34 -18 -40 2 -38 Z"); }
+}
+.ol-l13-wrap { animation: ol-l13-roll 2.4s ease-in-out infinite alternate; }
+.ol-l13 path { animation: ol-l13-wob 1.2s ease-in-out infinite; }
+
+/* 14 Infinity flow */
+@keyframes ol-l14-dash { to { stroke-dashoffset: -400; } }
+.ol-l14 path { stroke-dasharray: 60 340; animation: ol-l14-dash 2s linear infinite; }
+
+/* 15 Dripping blob */
+@keyframes ol-l15-drip {
+  0%   { d: path("M 100 40 C 130 40 150 60 150 90 C 150 120 125 140 100 140 C 75 140 50 120 50 90 C 50 60 70 40 100 40 Z"); }
+  50%  { d: path("M 100 40 C 130 40 150 60 150 95 C 150 125 120 155 100 170 C 80 155 50 125 50 95 C 50 60 70 40 100 40 Z"); }
+  100% { d: path("M 100 40 C 130 40 150 60 150 90 C 150 120 125 140 100 140 C 75 140 50 120 50 90 C 50 60 70 40 100 40 Z"); }
+}
+@keyframes ol-l15-drop {
+  0%   { transform: translateY(0); opacity: 0; }
+  20%  { opacity: 1; }
+  80%  { transform: translateY(40px); opacity: 1; }
+  100% { transform: translateY(60px); opacity: 0; }
+}
+.ol-l15 path { animation: ol-l15-drip 2s ease-in-out infinite; }
+.ol-l15 circle { animation: ol-l15-drop 2s ease-in infinite; }
+
+/* 16 Soft bar wave */
+@keyframes ol-l16-wave { 0%,100% { transform: scaleY(.4); } 50% { transform: scaleY(1); } }
+.ol-l16 rect { transform-origin: center; transform-box: fill-box; animation: ol-l16-wave 1.2s ease-in-out infinite; }
+.ol-l16 rect:nth-child(1) { animation-delay: 0s; }
+.ol-l16 rect:nth-child(2) { animation-delay: .12s; }
+.ol-l16 rect:nth-child(3) { animation-delay: .24s; }
+.ol-l16 rect:nth-child(4) { animation-delay: .36s; }
+.ol-l16 rect:nth-child(5) { animation-delay: .48s; }
+
+/* 17 Spiral tail */
+@keyframes ol-l17-rotate { to { transform: rotate(360deg); } }
+@keyframes ol-l17-dash {
+  0%   { stroke-dasharray: 1 200; stroke-dashoffset: 0; }
+  50%  { stroke-dasharray: 120 200; stroke-dashoffset: -40; }
+  100% { stroke-dasharray: 1 200; stroke-dashoffset: -200; }
+}
+.ol-l17-wrap { animation: ol-l17-rotate 1.6s linear infinite; transform-origin: 50% 50%; }
+.ol-l17 path { animation: ol-l17-dash 1.6s ease-in-out infinite; }
+
+/* 18 Two-tone bean */
+@keyframes ol-l18-spin { to { transform: rotate(360deg); } }
+@keyframes ol-l18-squish {
+  0%,100% { d: path("M 60 100 C 60 70 80 50 110 50 C 150 50 160 80 150 110 C 140 140 110 150 90 145 C 65 140 60 125 60 100 Z"); }
+  50%     { d: path("M 55 100 C 55 65 85 45 115 55 C 150 65 155 90 145 115 C 135 140 100 155 80 145 C 60 135 55 120 55 100 Z"); }
+}
+.ol-l18-wrap { animation: ol-l18-spin 2.4s linear infinite; transform-origin: 50% 50%; }
+.ol-l18 path { animation: ol-l18-squish 1.6s ease-in-out infinite; }
+
+/* 19 Bouncing caterpillar */
+@keyframes ol-l19-bounce { 0%,100% { transform: translateY(0); } 50% { transform: translateY(-14px); } }
+.ol-l19 circle { animation: ol-l19-bounce 1.2s ease-in-out infinite; }
+.ol-l19 circle:nth-child(1) { animation-delay: 0s; }
+.ol-l19 circle:nth-child(2) { animation-delay: .1s; }
+.ol-l19 circle:nth-child(3) { animation-delay: .2s; }
+.ol-l19 circle:nth-child(4) { animation-delay: .3s; }
+.ol-l19 circle:nth-child(5) { animation-delay: .4s; }
+
+/* 20 Gooey orbit */
+@keyframes ol-l20-orbit-a { to { transform: rotate(360deg); } }
+@keyframes ol-l20-orbit-b { to { transform: rotate(-360deg); } }
+@keyframes ol-l20-pulse { 0%,100% { r: 16; } 50% { r: 22; } }
+.ol-l20-a { animation: ol-l20-orbit-a 3s linear infinite; transform-origin: 50% 50%; }
+.ol-l20-b { animation: ol-l20-orbit-b 2s linear infinite; transform-origin: 50% 50%; }
+.ol-l20 .core { animation: ol-l20-pulse 1.2s ease-in-out infinite; }
+
+@media (prefers-reduced-motion: reduce) {
+  [class*="ol-l"] { animation-duration: 6s !important; }
+}
+
+.hearth-dark-btn {
+  background: var(--text-primary);
+  color: var(--bg-base);
+  border: 0;
+  padding: 7px 14px;
+  border-radius: 999px;
+  font-size: 12px;
+  font-weight: 500;
+  font-family: inherit;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  cursor: pointer;
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,6 +1,18 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App';
+
+// Hearth fonts — Fraunces (display serif), Geist (body sans), IBM Plex Mono (captions/times)
+import '@fontsource/fraunces/400.css';
+import '@fontsource/fraunces/500.css';
+import '@fontsource/fraunces/600.css';
+import '@fontsource/fraunces/400-italic.css';
+import '@fontsource/geist/400.css';
+import '@fontsource/geist/500.css';
+import '@fontsource/geist/600.css';
+import '@fontsource/ibm-plex-mono/400.css';
+import '@fontsource/ibm-plex-mono/500.css';
+
 import './index.css';
 
 ReactDOM.createRoot(document.getElementById('root')!).render(

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -5,6 +5,59 @@ export default {
   theme: {
     extend: {
       colors: {
+        /* Remap emerald → terracotta (Hearth accent) so all existing
+           emerald-* classes pick up the Hearth accent automatically. */
+        emerald: {
+          50:  '#faeadd',
+          100: '#f7e6d8', /* accent-wash */
+          200: '#f0c8b0',
+          300: '#e8a585',
+          400: '#de8c69',
+          500: '#d97757', /* accent */
+          600: '#c26547',
+          700: '#a5532f',
+          800: '#843e20',
+          900: '#5e2c18',
+        },
+        /* Remap neutral grays to warm Hearth tones */
+        /* teal also maps to terracotta (FirstVisitView uses teal-500/600) */
+        teal: {
+          50:  '#faeadd',
+          100: '#f7e6d8',
+          200: '#f0c8b0',
+          300: '#e8a585',
+          400: '#de8c69',
+          500: '#d97757',
+          600: '#c26547',
+          700: '#a5532f',
+          800: '#843e20',
+          900: '#5e2c18',
+        },
+        /* amber → cream (warm yellow). keeps Hearth palette. */
+        amber: {
+          50:  '#fbf3de',
+          100: '#f7e8c2',
+          200: '#f0d894',
+          300: '#e8c466',
+          400: '#d4a245',
+          500: '#b8852b',
+          600: '#996d1f',
+          700: '#785418',
+          800: '#564012',
+          900: '#35280c',
+        },
+        gray: {
+          50:  '#faf4ec',
+          100: '#f2e9dd', /* sand */
+          200: '#ece1d1', /* rule */
+          300: '#d9c8ad',
+          400: '#97897a', /* ink3 */
+          500: '#655a4f', /* ink2 */
+          600: '#4a4036',
+          700: '#332c25',
+          800: '#25201b',
+          900: '#1e1a16', /* ink */
+        },
         base: 'var(--bg-base)',
         surface: 'var(--bg-surface)',
         elevated: 'var(--bg-elevated)',
@@ -30,11 +83,22 @@ export default {
         'imessage-blue': '#007AFF',
         'imessage-green': '#34C759',
         'bubble-gray': 'var(--bg-elevated)',
+        'bubble-me': 'var(--bubble-me)',
+        'bubble-them': 'var(--bubble-them)',
+        sand: 'var(--bg-elevated)',
+        sage: 'var(--sage)',
+        cream: 'var(--cream)',
+        ink: 'var(--text-primary)',
+        ink2: 'var(--text-secondary)',
+        ink3: 'var(--text-tertiary)',
+        rule: 'var(--border-default)',
+        'accent-wash': 'var(--accent-wash)',
       },
       fontFamily: {
-        sans: ['-apple-system', 'BlinkMacSystemFont', 'SF Pro Text', 'Segoe UI', 'system-ui', 'sans-serif'],
-        display: ['-apple-system', 'BlinkMacSystemFont', 'SF Pro Display', 'Segoe UI', 'system-ui', 'sans-serif'],
-        mono: ['SF Mono', 'Menlo', 'Consolas', 'monospace'],
+        sans: ['Geist', '-apple-system', 'BlinkMacSystemFont', 'Segoe UI', 'system-ui', 'sans-serif'],
+        display: ['Geist', '-apple-system', 'BlinkMacSystemFont', 'Segoe UI', 'system-ui', 'sans-serif'],
+        serif: ['Fraunces', 'Newsreader', 'Georgia', 'serif'],
+        mono: ['IBM Plex Mono', 'SF Mono', 'Menlo', 'monospace'],
       },
       borderRadius: {
         sm: '6px',


### PR DESCRIPTION
## Summary
- Rebuild the desktop app around the **Hearth** variant from the App Mockups design bundle: warm cream palette, terracotta accent, Fraunces serif titles, Geist body, IBM Plex Mono captions. Emerald/teal/gray Tailwind scales are remapped so existing classes pick up Hearth tones automatically. Mockup bundle preserved under `mockups/app/` with Hearth pre-selected.
- Add **OrganicLoader** component with all 20 blobby SVG+CSS indicators from the Organic Loaders bundle. Picks a random variant per mount, cascades `currentColor`, stays centered at any size via an absolute-positioned scale wrapper. Wired into the app loading screen, backup dashboard skeleton, every explore screen's loading state, and the password-unlock button — continuous loader feedback from password submit through dashboard hydration.
- Surface previously-silent failures when browsing for a backup folder via a Hearth-styled error toast, so picking a non-backup folder tells the user what to try instead of doing nothing.

## Test plan
- [ ] `npm run dev` and verify the first-visit, returning, and workspace home screens render in Hearth palette with Fraunces titles.
- [ ] Open an encrypted backup and confirm the Unlock button shows an organic loader + "Unlocking…" while the sidecar runs.
- [ ] Navigate Dashboard → Timeline → Messages → Photos → Voicemail → Calls → Contacts → Notes and confirm every loading state shows an organic loader (different variants at random).
- [ ] Click "Explore my data" and pick a non-backup folder; confirm the error toast appears with guidance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)