### PR TITLE
chore: release v0.5.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openextract",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openextract",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "license": "MIT",
       "dependencies": {
         "@fontsource/fraunces": "^5.2.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openextract",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Free, open-source iPhone backup extractor",
   "main": "dist-electron/main.js",
   "author": "OpenExtract Contributors",

--- a/website/static/index.html
+++ b/website/static/index.html
@@ -102,7 +102,7 @@
       </h1>
       <p class="hero__sub">Pull the messages, photos, and voicemails out of any old iPhone backup — right on your own laptop. Nothing uploaded, nothing paid, nothing to sign up for.</p>
       <div class="hero__ctas">
-        <a class="btn btn--primary" href="https://github.com/charleswest775/openextract/releases/download/v0.4.0/OpenExtract-0.4.0-arm64.dmg">Download for Mac<span>· 144 MB</span></a>
+        <a class="btn btn--primary" href="https://github.com/charleswest775/openextract/releases/download/v0.5.0/OpenExtract-0.5.0-arm64.dmg">Download for Mac<span>· 144 MB</span></a>
         <a class="btn btn--ghost" href="#download">Windows &amp; Linux →</a>
       </div>
       <div class="hero__social">
@@ -364,15 +364,15 @@
         <h2>Get your <span class="it it--coral">memories</span> back.</h2>
         <p class="final-cta__lede">Download OpenExtract, point it at a backup, and see what's in there. Takes about two minutes.</p>
         <div class="final-cta__grid">
-          <a class="dl-card dl-card--primary" href="https://github.com/charleswest775/openextract/releases/download/v0.4.0/OpenExtract-0.4.0-arm64.dmg">
+          <a class="dl-card dl-card--primary" href="https://github.com/charleswest775/openextract/releases/download/v0.5.0/OpenExtract-0.5.0-arm64.dmg">
             <div class="dl-card__os">Download for macOS</div>
             <div class="dl-card__meta">144 MB · Apple Silicon</div>
           </a>
-          <a class="dl-card" href="https://github.com/charleswest775/openextract/releases/download/v0.4.0/OpenExtract-Setup-0.4.0.exe">
+          <a class="dl-card" href="https://github.com/charleswest775/openextract/releases/download/v0.5.0/OpenExtract-Setup-0.5.0.exe">
             <div class="dl-card__os">Download for Windows</div>
             <div class="dl-card__meta">175 MB · 10 &amp; 11</div>
           </a>
-          <a class="dl-card" href="https://github.com/charleswest775/openextract/releases/download/v0.4.0/OpenExtract-0.4.0.AppImage">
+          <a class="dl-card" href="https://github.com/charleswest775/openextract/releases/download/v0.5.0/OpenExtract-0.5.0.AppImage">
             <div class="dl-card__os">Download for Linux</div>
             <div class="dl-card__meta">176 MB · AppImage</div>
           </a>


### PR DESCRIPTION
Auto-opened after the v0.5.0 Release workflow published artifacts. The workflow's automatic PR step failed (GitHub Actions isn't permitted to create PRs in this repo), so this is being opened manually.

Merging keeps `main` in sync: version bump in `package.json` and updated download URLs in `website/static/index.html`.

Release: https://github.com/charleswest775/openextract/releases/tag/v0.5.0