### PR TITLE
site: route downloads through /download/* with Vercel redirects

### DIFF
--- a/website/static/how-it-works.html
+++ b/website/static/how-it-works.html
@@ -116,17 +116,17 @@
         <p>If you don't have a backup yet, plug your iPhone in, open Finder (or iTunes on Windows), and click "Back up now." Then come back here.</p>
       </div>
       <div class="inline-download__list">
-        <a class="dl-row dl-row--primary" href="https://github.com/charleswest775/openextract/releases/download/v0.4.0/OpenExtract-0.4.0-arm64.dmg">
+        <a class="dl-row dl-row--primary" href="/download/mac">
           <span class="dl-row__os">Download for macOS</span>
-          <span class="dl-row__meta">Apple Silicon · 144 MB</span>
+          <span class="dl-row__meta">Apple Silicon · 149 MB</span>
         </a>
-        <a class="dl-row" href="https://github.com/charleswest775/openextract/releases/download/v0.4.0/OpenExtract-Setup-0.4.0.exe">
+        <a class="dl-row" href="/download/windows">
           <span class="dl-row__os">Download for Windows</span>
-          <span class="dl-row__meta">10 &amp; 11 · 175 MB</span>
+          <span class="dl-row__meta">10 &amp; 11 · 180 MB</span>
         </a>
-        <a class="dl-row" href="https://github.com/charleswest775/openextract/releases/download/v0.4.0/OpenExtract-0.4.0.AppImage">
+        <a class="dl-row" href="/download/linux">
           <span class="dl-row__os">Download for Linux</span>
-          <span class="dl-row__meta">AppImage · 176 MB</span>
+          <span class="dl-row__meta">AppImage · 181 MB</span>
         </a>
       </div>
     </div>

--- a/website/static/index.html
+++ b/website/static/index.html
@@ -102,7 +102,7 @@
       </h1>
       <p class="hero__sub">Pull the messages, photos, and voicemails out of any old iPhone backup — right on your own laptop. Nothing uploaded, nothing paid, nothing to sign up for.</p>
       <div class="hero__ctas">
-        <a class="btn btn--primary" href="https://github.com/charleswest775/openextract/releases/download/v0.5.0/OpenExtract-0.5.0-arm64.dmg">Download for Mac<span>· 144 MB</span></a>
+        <a class="btn btn--primary" href="/download/mac">Download for Mac<span>· 149 MB</span></a>
         <a class="btn btn--ghost" href="#download">Windows &amp; Linux →</a>
       </div>
       <div class="hero__social">
@@ -364,17 +364,17 @@
         <h2>Get your <span class="it it--coral">memories</span> back.</h2>
         <p class="final-cta__lede">Download OpenExtract, point it at a backup, and see what's in there. Takes about two minutes.</p>
         <div class="final-cta__grid">
-          <a class="dl-card dl-card--primary" href="https://github.com/charleswest775/openextract/releases/download/v0.5.0/OpenExtract-0.5.0-arm64.dmg">
+          <a class="dl-card dl-card--primary" href="/download/mac">
             <div class="dl-card__os">Download for macOS</div>
-            <div class="dl-card__meta">144 MB · Apple Silicon</div>
+            <div class="dl-card__meta">149 MB · Apple Silicon</div>
           </a>
-          <a class="dl-card" href="https://github.com/charleswest775/openextract/releases/download/v0.5.0/OpenExtract-Setup-0.5.0.exe">
+          <a class="dl-card" href="/download/windows">
             <div class="dl-card__os">Download for Windows</div>
-            <div class="dl-card__meta">175 MB · 10 &amp; 11</div>
+            <div class="dl-card__meta">180 MB · 10 &amp; 11</div>
           </a>
-          <a class="dl-card" href="https://github.com/charleswest775/openextract/releases/download/v0.5.0/OpenExtract-0.5.0.AppImage">
+          <a class="dl-card" href="/download/linux">
             <div class="dl-card__os">Download for Linux</div>
-            <div class="dl-card__meta">176 MB · AppImage</div>
+            <div class="dl-card__meta">181 MB · AppImage</div>
           </a>
         </div>
         <div class="final-cta__brew">or: <code>brew install openextract</code></div>

--- a/website/static/vercel.json
+++ b/website/static/vercel.json
@@ -1,3 +1,20 @@
 {
-  "cleanUrls": true
+  "cleanUrls": true,
+  "redirects": [
+    {
+      "source": "/download/mac",
+      "destination": "https://github.com/charleswest775/openextract/releases/download/v0.5.0/OpenExtract-0.5.0-arm64.dmg",
+      "permanent": false
+    },
+    {
+      "source": "/download/windows",
+      "destination": "https://github.com/charleswest775/openextract/releases/download/v0.5.0/OpenExtract-Setup-0.5.0.exe",
+      "permanent": false
+    },
+    {
+      "source": "/download/linux",
+      "destination": "https://github.com/charleswest775/openextract/releases/download/v0.5.0/OpenExtract-0.5.0.AppImage",
+      "permanent": false
+    }
+  ]
 }


### PR DESCRIPTION
## Summary

Replaces seven hard-coded GitHub release URLs across the site with three stable internal paths, and puts the actual GitHub asset URLs in \`vercel.json\` as redirects.

**Stable paths**

| Internal path | → | Current destination |
|---|---|---|
| \`/download/mac\` | → | \`v0.5.0/OpenExtract-0.5.0-arm64.dmg\` |
| \`/download/windows\` | → | \`v0.5.0/OpenExtract-Setup-0.5.0.exe\` |
| \`/download/linux\` | → | \`v0.5.0/OpenExtract-0.5.0.AppImage\` |

Redirects use \`permanent: false\` (HTTP 307) so browsers don't cache the old destination across releases.

**Why**

Previously every release required updating four download cards in \`index.html\` plus three rows in \`how-it-works.html\` — and the release workflow only auto-bumped one of those files (the v0.5.0 release left how-it-works on v0.4.0). With this setup, per-release maintenance is one file (vercel.json) and three URLs.

Sizes refreshed to v0.5.0 (149 MB / 180 MB / 181 MB).

## Test plan

- [ ] Vercel preview builds
- [ ] \`curl -I https://<preview>/download/mac\` returns a 307 to the v0.5.0 dmg
- [ ] Same for /download/windows and /download/linux
- [ ] After merge, production \`/download/mac\` etc. redirect to v0.5.0 assets
- [ ] Clicking each download card on the live site downloads the correct installer

🤖 Generated with [Claude Code](https://claude.com/claude-code)