### PR TITLE
chore: release v0.5.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openextract",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openextract",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "license": "MIT",
       "dependencies": {
         "@fontsource/fraunces": "^5.2.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openextract",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Free, open-source iPhone backup extractor",
   "main": "dist-electron/main.js",
   "author": "OpenExtract Contributors",


### PR DESCRIPTION
Auto-opening this sync PR manually (workflow couldn't because "Allow GitHub Actions to create and approve pull requests" is disabled in repo settings).

Brings to `main`:
- Version bump in `package.json` to 0.5.1
- Updated download URLs in `website/static/index.html` for v0.5.1 installers

Release v0.5.1 is already published with signed Mac/Windows/Linux installers: https://github.com/charleswest775/openextract/releases/tag/v0.5.1