### PR TITLE
site: bump v0.5.1 download URLs and harden release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -128,24 +128,51 @@ jobs:
         run: npm run build
 
       # --- Update website download URLs on the release branch ---
+      # Touches two files:
+      #   - website/static/index.html: nav version pill + installer filename refs.
+      #     Nav copy may be `v0.4` (no patch) or `v0.4.0`; both should bump cleanly.
+      #   - website/static/vercel.json: /download/{mac,windows,linux} redirects
+      #     point at the GitHub release asset for this version. If we don't update
+      #     vercel.json, the website keeps serving the previous version's binaries.
       - name: Update website version and download URLs
         run: |
           VERSION="${{ inputs.version }}"
-          FILE="website/static/index.html"
-          if [ -f "$FILE" ]; then
-            sed -i "s/v[0-9]\+\.[0-9]\+\.[0-9]\+/v${VERSION}/g" "$FILE"
-            sed -i "s/OpenExtract-Setup-[0-9]\+\.[0-9]\+\.[0-9]\+/OpenExtract-Setup-${VERSION}/g" "$FILE"
-            sed -i "s/OpenExtract-[0-9]\+\.[0-9]\+\.[0-9]\+-arm64/OpenExtract-${VERSION}-arm64/g" "$FILE"
-            sed -i "s/OpenExtract-[0-9]\+\.[0-9]\+\.[0-9]\+\.AppImage/OpenExtract-${VERSION}.AppImage/g" "$FILE"
-            if git diff --quiet "$FILE"; then
-              echo "No website changes needed"
-            else
-              git add "$FILE"
-              git commit -m "chore: update website download URLs to v${VERSION}"
-              echo "Website updated to v${VERSION}"
+          STAGED=0
+
+          INDEX="website/static/index.html"
+          if [ -f "$INDEX" ]; then
+            # nav version pill — match vX.Y or vX.Y.Z so a 2-segment value still bumps.
+            sed -i "s/v[0-9]\+\.[0-9]\+\(\.[0-9]\+\)\?/v${VERSION}/g" "$INDEX"
+            sed -i "s/OpenExtract-Setup-[0-9]\+\.[0-9]\+\.[0-9]\+/OpenExtract-Setup-${VERSION}/g" "$INDEX"
+            sed -i "s/OpenExtract-[0-9]\+\.[0-9]\+\.[0-9]\+-arm64/OpenExtract-${VERSION}-arm64/g" "$INDEX"
+            sed -i "s/OpenExtract-[0-9]\+\.[0-9]\+\.[0-9]\+\.AppImage/OpenExtract-${VERSION}.AppImage/g" "$INDEX"
+            if ! git diff --quiet "$INDEX"; then
+              git add "$INDEX"
+              STAGED=1
+              echo "index.html updated to v${VERSION}"
             fi
           else
-            echo "No website/static/index.html found, skipping"
+            echo "No $INDEX found, skipping"
+          fi
+
+          VERCEL="website/static/vercel.json"
+          if [ -f "$VERCEL" ]; then
+            # Redirects embed the version in both the path segment and the filename,
+            # so a single regex over X.Y.Z occurrences swaps both at once.
+            sed -i "s/[0-9]\+\.[0-9]\+\.[0-9]\+/${VERSION}/g" "$VERCEL"
+            if ! git diff --quiet "$VERCEL"; then
+              git add "$VERCEL"
+              STAGED=1
+              echo "vercel.json updated to v${VERSION}"
+            fi
+          else
+            echo "No $VERCEL found, skipping"
+          fi
+
+          if [ "$STAGED" = "1" ]; then
+            git commit -m "chore: update website download URLs to v${VERSION}"
+          else
+            echo "No website changes needed"
           fi
 
       # --- Push release branch (release/* is not protected) and tag ---

--- a/website/static/index.html
+++ b/website/static/index.html
@@ -79,7 +79,7 @@
     <a href="/" class="nav__brand">
       <div class="nav__logo" aria-hidden="true">o</div>
       <span class="nav__wordmark">OpenExtract</span>
-      <span class="nav__version">v0.4</span>
+      <span class="nav__version">v0.5.1</span>
     </a>
     <div class="nav__links">
       <a href="/how-it-works">How it works</a>
@@ -102,7 +102,7 @@
       </h1>
       <p class="hero__sub">Pull the messages, photos, and voicemails out of any old iPhone backup — right on your own laptop. Nothing uploaded, nothing paid, nothing to sign up for.</p>
       <div class="hero__ctas">
-        <a class="btn btn--primary" href="/download/mac">Download for Mac<span>· 149 MB</span></a>
+        <a class="btn btn--primary" href="/download/mac">Download for Mac<span>· 144 MB</span></a>
         <a class="btn btn--ghost" href="#download">Windows &amp; Linux →</a>
       </div>
       <div class="hero__social">
@@ -366,15 +366,15 @@
         <div class="final-cta__grid">
           <a class="dl-card dl-card--primary" href="/download/mac">
             <div class="dl-card__os">Download for macOS</div>
-            <div class="dl-card__meta">149 MB · Apple Silicon</div>
+            <div class="dl-card__meta">144 MB · Apple Silicon</div>
           </a>
           <a class="dl-card" href="/download/windows">
             <div class="dl-card__os">Download for Windows</div>
-            <div class="dl-card__meta">180 MB · 10 &amp; 11</div>
+            <div class="dl-card__meta">176 MB · 10 &amp; 11</div>
           </a>
           <a class="dl-card" href="/download/linux">
             <div class="dl-card__os">Download for Linux</div>
-            <div class="dl-card__meta">181 MB · AppImage</div>
+            <div class="dl-card__meta">175 MB · AppImage</div>
           </a>
         </div>
         <div class="final-cta__brew">or: <code>brew install openextract</code></div>

--- a/website/static/vercel.json
+++ b/website/static/vercel.json
@@ -3,17 +3,17 @@
   "redirects": [
     {
       "source": "/download/mac",
-      "destination": "https://github.com/charleswest775/openextract/releases/download/v0.5.0/OpenExtract-0.5.0-arm64.dmg",
+      "destination": "https://github.com/charleswest775/openextract/releases/download/v0.5.1/OpenExtract-0.5.1-arm64.dmg",
       "permanent": false
     },
     {
       "source": "/download/windows",
-      "destination": "https://github.com/charleswest775/openextract/releases/download/v0.5.0/OpenExtract-Setup-0.5.0.exe",
+      "destination": "https://github.com/charleswest775/openextract/releases/download/v0.5.1/OpenExtract-Setup-0.5.1.exe",
       "permanent": false
     },
     {
       "source": "/download/linux",
-      "destination": "https://github.com/charleswest775/openextract/releases/download/v0.5.0/OpenExtract-0.5.0.AppImage",
+      "destination": "https://github.com/charleswest775/openextract/releases/download/v0.5.1/OpenExtract-0.5.1.AppImage",
       "permanent": false
     }
   ]


### PR DESCRIPTION
## Summary
- v0.5.1 release workflow shipped artifacts but didn't update the website's actual download targets. `website/static/vercel.json` (the source of `/download/{mac,windows,linux}` redirects) still pointed at v0.5.0 binaries, and `website/static/index.html` still showed v0.4 in the nav with stale installer sizes.
- This PR patches v0.5.1 directly and hardens `.github/workflows/release.yml` so future bumps update both files and don't silently skip the nav version because of a regex that requires three segments.

## Changes
- `website/static/vercel.json`: redirects → v0.5.1 release assets
- `website/static/index.html`: nav v0.5.1, installer sizes Mac 144 / Win 176 / Linux 175 MB
- `.github/workflows/release.yml`: rewrites vercel.json on release + accepts vX.Y nav pill

## Test plan
- [ ] After merge, hit https://www.openextract.app/download/windows and confirm it 302s to v0.5.1's exe
- [ ] After next release (vX.Y.Z bump), confirm both vercel.json and index.html are updated in the auto-opened sync PR