### PR TITLE
fix: install ios-backup-core from GitHub for simpler dev setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,19 +39,8 @@ jobs:
       - name: TypeScript check (electron)
         run: npx tsc --noEmit -p tsconfig.electron.json
 
-      # python/requirements.txt installs ios-backup-core via `-e ../../ios-backup-core`.
-      # The expected layout is openextract/ and ios-backup-core/ as siblings on disk,
-      # so clone ios-backup-core one level above $GITHUB_WORKSPACE before pip runs.
-      # TODO: remove this step once ios-backup-core ships to PyPI and requirements.txt
-      # pins a versioned release instead of the editable path install.
-      - name: Clone ios-backup-core (sibling for editable install)
-        run: |
-          git clone --depth=1 \
-            https://github.com/charleswest775/ios-backup-core.git \
-            "$GITHUB_WORKSPACE/../ios-backup-core"
-
-      # Run from python/ so pip resolves `-e ../../ios-backup-core` the same
-      # way it does locally (README tells devs to `cd python` first).
+      # ios-backup-core is installed from GitHub via requirements.txt.
+      # TODO: pin a PyPI release once ios-backup-core is published.
       - name: Install Python dependencies
         working-directory: python
         run: pip install ruff pytest -r requirements.txt

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -100,20 +100,8 @@ jobs:
       - name: TypeScript check (electron)
         run: npx tsc --noEmit -p tsconfig.electron.json
 
-      # python/requirements.txt installs ios-backup-core via `-e ../../ios-backup-core`.
-      # The expected layout is openextract/ and ios-backup-core/ as siblings on disk,
-      # so clone ios-backup-core one level above $GITHUB_WORKSPACE before pip runs.
-      # TODO: remove this step once ios-backup-core ships to PyPI and requirements.txt
-      # pins a versioned release instead of the editable path install.
-      - name: Clone ios-backup-core (sibling for editable install)
-        shell: bash
-        run: |
-          git clone --depth=1 \
-            https://github.com/charleswest775/ios-backup-core.git \
-            "$GITHUB_WORKSPACE/../ios-backup-core"
-
-      # Run from python/ so pip resolves `-e ../../ios-backup-core` the same
-      # way it does locally (README tells devs to `cd python` first).
+      # ios-backup-core is installed from GitHub via requirements.txt.
+      # TODO: pin a PyPI release once ios-backup-core is published.
       - name: Install Python dependencies
         working-directory: python
         run: pip install ruff pytest -r requirements.txt
@@ -219,14 +207,6 @@ jobs:
       - name: Install Node dependencies
         run: npm install
 
-      # See preflight job for rationale on sibling-clone + working-directory.
-      - name: Clone ios-backup-core (sibling for editable install)
-        shell: bash
-        run: |
-          git clone --depth=1 \
-            https://github.com/charleswest775/ios-backup-core.git \
-            "$GITHUB_WORKSPACE/../ios-backup-core"
-
       - name: Install Python dependencies and PyInstaller
         working-directory: python
         run: pip install pyinstaller -r requirements.txt
@@ -272,14 +252,6 @@ jobs:
 
       - name: Install Node dependencies
         run: npm install
-
-      # See preflight job for rationale on sibling-clone + working-directory.
-      - name: Clone ios-backup-core (sibling for editable install)
-        shell: bash
-        run: |
-          git clone --depth=1 \
-            https://github.com/charleswest775/ios-backup-core.git \
-            "$GITHUB_WORKSPACE/../ios-backup-core"
 
       - name: Install Python dependencies and PyInstaller
         working-directory: python
@@ -329,14 +301,6 @@ jobs:
 
       - name: Install Node dependencies
         run: npm install
-
-      # See preflight job for rationale on sibling-clone + working-directory.
-      - name: Clone ios-backup-core (sibling for editable install)
-        shell: bash
-        run: |
-          git clone --depth=1 \
-            https://github.com/charleswest775/ios-backup-core.git \
-            "$GITHUB_WORKSPACE/../ios-backup-core"
 
       - name: Install Python dependencies and PyInstaller
         working-directory: python

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,6 +24,14 @@ cd python && pip install -r requirements.txt && cd ..
 npm run dev
 ```
 
+`pip install -r requirements.txt` installs `ios-backup-core` from GitHub. No sibling checkout is required.
+
+If you are developing `ios-backup-core` locally alongside OpenExtract, override with an editable install:
+
+```bash
+pip install -e ../ios-backup-core
+```
+
 ## Commit Convention
 
 We use [Conventional Commits](https://www.conventionalcommits.org/):

--- a/README.md
+++ b/README.md
@@ -33,16 +33,16 @@ cd openextract
 # Install Node dependencies
 npm install
 
-# Install Python dependencies
-cd python
-pip install -r requirements.txt
-cd ..
+# Create a venv and install Python dependencies (pulls ios-backup-core from GitHub)
+python -m venv .venv
+source .venv/bin/activate          # Windows: .venv\Scripts\activate
+cd python && pip install -r requirements.txt && cd ..
 
 # Start the development server
 npm run dev
 ```
 
-This will launch Vite (React dev server) and Electron together. The app will auto-detect iPhone backups in the default locations:
+Electron uses `.venv` automatically in development. This will launch Vite (React dev server) and Electron together. The app will auto-detect iPhone backups in the default locations:
 
 - **macOS:** `~/Library/Application Support/MobileSync/Backup/`
 - **Windows:** `%APPDATA%\Apple Computer\MobileSync\Backup\`

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -5,10 +5,7 @@ debugpy>=1.8.0
 pymobiledevice3>=4.0.0
 reportlab>=4.0
 # ios-backup-core is the shared iPhone-backup parsing library extracted from
-# this codebase. Until it is published to PyPI, install it from a sibling
-# checkout:  pip install -e ../../ios-backup-core
-# (Path is relative to this requirements.txt — `dev/openextract/python/` →
-#  `dev/ios-backup-core/`. In a git worktree the relative path won't resolve;
-#  install the lib separately from its absolute path in that case.)
--e ../../ios-backup-core
-
+# this codebase. Until it is published to PyPI, install it from GitHub so
+# `pip install -r requirements.txt` works without a sibling checkout.
+# For local dual-repo development: pip install -e ../ios-backup-core
+ios-backup-core @ git+https://github.com/charleswest775/ios-backup-core.git


### PR DESCRIPTION
## Summary
- Install `ios-backup-core` from GitHub in `python/requirements.txt` so new developers no longer need a sibling checkout
- Remove the sibling-clone steps from CI and release workflows
- Document venv setup and the optional local editable override in README/CONTRIBUTING

## Test plan
- [ ] Fresh clone: `npm install`, create `.venv`, `pip install -r python/requirements.txt`, `npm run dev`
- [ ] Confirm Python sidecar starts without `ModuleNotFoundError: ios_backup_core`
- [ ] Confirm CI installs Python deps without a sibling clone
- [ ] Optional: `pip install -e ../ios-backup-core` still overrides for dual-repo work


Made with [Cursor](https://cursor.com)