### PR TITLE
Include attachments when exporting html or csv

### DIFF
--- a/python/messages.py
+++ b/python/messages.py
@@ -232,7 +232,7 @@ class MessageExtractor:
         elif fmt == "csv":
             return self._export_csv(all_messages, chat_id, output_dir, backup=backup)
         elif fmt == "html":
-            return self._export_html(all_messages, chat_id, output_dir)
+            return self._export_html(all_messages, chat_id, output_dir, backup=backup)
         else:
             return {"error": f"Unsupported format: {fmt}"}
 
@@ -409,9 +409,53 @@ class MessageExtractor:
             "attachments_failed": failed_files,
         }
 
-    def _export_html(self, messages, chat_id, output_dir):
+    def _html_attachment_markup(self, msg, path_map: dict) -> str:
+        """Build HTML for a message's exported attachments (images + file links)."""
+        parts = []
+        for att in msg.get("attachments") or []:
+            att_id = att.get("attachment_id")
+            rel = path_map.get(att_id) if att_id is not None else None
+            if not rel:
+                continue
+            name = self._attachment_display_name(att) or os.path.basename(rel)
+            mime = (att.get("mime_type") or "").lower()
+            safe_src = html.escape(rel, quote=True)
+            safe_name = html.escape(name)
+            if mime.startswith("image/"):
+                parts.append(
+                    f'<div class="att"><img src="{safe_src}" alt="{safe_name}"></div>'
+                )
+            else:
+                parts.append(
+                    f'<div class="att"><a href="{safe_src}">{safe_name}</a></div>'
+                )
+        return "".join(parts)
+
+    def _html_message_body(self, msg, path_map: dict) -> str:
+        text = (msg.get("text") or "").strip()
+        att_html = self._html_attachment_markup(msg, path_map)
+        if text:
+            body = html.escape(text).replace("\n", "<br>\n")
+            if att_html:
+                return body + att_html
+            return body
+        if att_html:
+            return att_html
+        return "[Attachment]"
+
+    def _export_html(self, messages, chat_id, output_dir, backup=None):
         filename = f"conversation_{chat_id}.html"
         filepath = os.path.join(output_dir, filename)
+
+        attachments_dir = os.path.join(output_dir, "attachments")
+        path_map: dict = {}
+        exported_files = 0
+        failed_files = 0
+        if backup is not None:
+            path_map, exported_files, failed_files = self._export_attachment_files(
+                backup, messages, attachments_dir
+            )
+
         with open(filepath, "w", encoding="utf-8") as f:
             f.write("""<!DOCTYPE html>
 <html><head><meta charset="utf-8"><title>Conversation Export</title>
@@ -422,18 +466,27 @@ body { font-family: -apple-system, sans-serif; max-width: 600px; margin: 0 auto;
 .received { background: #E9E9EB; color: black; float: left; border-bottom-left-radius: 4px; }
 .meta { font-size: 11px; color: #888; clear: both; text-align: center; margin: 12px 0 4px; }
 .sender { font-size: 11px; color: #666; margin-bottom: 2px; }
+.att { margin-top: 8px; }
+.att img { max-width: 100%; border-radius: 8px; display: block; }
+.att a { color: inherit; text-decoration: underline; word-break: break-all; }
 </style></head><body>
 """)
             for msg in messages:
                 css_class = "sent" if msg["is_from_me"] else "received"
-                text = msg["text"] or "[Attachment]"
-                date = msg["date"] or ""
+                body = self._html_message_body(msg, path_map)
+                date = html.escape(msg["date"] or "")
                 f.write(f'<div class="meta">{date}</div>\n')
                 if not msg["is_from_me"]:
-                    f.write(f'<div class="sender">{msg["sender"]}</div>\n')
-                f.write(f'<div class="msg {css_class}">{text}</div>\n')
+                    f.write(f'<div class="sender">{html.escape(msg["sender"])}</div>\n')
+                f.write(f'<div class="msg {css_class}">{body}</div>\n')
             f.write("</body></html>")
-        return {"file": filepath, "message_count": len(messages)}
+        return {
+            "file": filepath,
+            "attachments_dir": attachments_dir,
+            "message_count": len(messages),
+            "attachments_exported": exported_files,
+            "attachments_failed": failed_files,
+        }
 
     # ── Multi-conversation export ────────────────────────────────────────────
 
@@ -527,7 +580,7 @@ body { font-family: -apple-system, sans-serif; max-width: 600px; margin: 0 auto;
         elif fmt == "csv":
             return self._export_merged_csv(all_messages, output_dir, backup=backup)
         elif fmt == "html":
-            return self._export_merged_html(all_messages, output_dir)
+            return self._export_merged_html(all_messages, output_dir, backup=backup)
         else:
             return {"error": f"Unsupported format: {fmt}"}
 
@@ -576,8 +629,18 @@ body { font-family: -apple-system, sans-serif; max-width: 600px; margin: 0 auto;
             "attachments_failed": failed_files,
         }
 
-    def _export_merged_html(self, messages, output_dir):
+    def _export_merged_html(self, messages, output_dir, backup=None):
         filepath = os.path.join(output_dir, "all_conversations.html")
+
+        attachments_dir = os.path.join(output_dir, "attachments")
+        path_map: dict = {}
+        exported_files = 0
+        failed_files = 0
+        if backup is not None:
+            path_map, exported_files, failed_files = self._export_attachment_files(
+                backup, messages, attachments_dir
+            )
+
         with open(filepath, "w", encoding="utf-8") as f:
             f.write("""<!DOCTYPE html>
 <html><head><meta charset="utf-8"><title>Merged Conversations Export</title>
@@ -589,18 +652,30 @@ body { font-family: -apple-system, sans-serif; max-width: 700px; margin: 0 auto;
 .meta { font-size: 11px; color: #888; clear: both; text-align: center; margin: 12px 0 4px; }
 .sender { font-size: 11px; color: #666; margin-bottom: 2px; }
 .conv-label { font-size: 10px; color: #999; font-style: italic; }
+.att { margin-top: 8px; }
+.att img { max-width: 100%; border-radius: 8px; display: block; }
+.att a { color: inherit; text-decoration: underline; word-break: break-all; }
 </style></head><body>
 <h2>Merged Conversations</h2>
 """)
             for msg in messages:
                 css_class = "sent" if msg["is_from_me"] else "received"
-                text = msg["text"] or "[Attachment]"
-                date = msg["date"] or ""
-                conv = msg["_conversation"]
+                body = self._html_message_body(msg, path_map)
+                date = html.escape(msg["date"] or "")
+                conv = html.escape(msg["_conversation"])
                 direction = "to" if msg["is_from_me"] else "from"
-                f.write(f'<div class="meta">{date} <span class="conv-label">({direction} {conv})</span></div>\n')
+                f.write(
+                    f'<div class="meta">{date} '
+                    f'<span class="conv-label">({direction} {conv})</span></div>\n'
+                )
                 if not msg["is_from_me"]:
-                    f.write(f'<div class="sender">{msg["sender"]}</div>\n')
-                f.write(f'<div class="msg {css_class}">{text}</div>\n')
+                    f.write(f'<div class="sender">{html.escape(msg["sender"])}</div>\n')
+                f.write(f'<div class="msg {css_class}">{body}</div>\n')
             f.write("</body></html>")
-        return {"files": [filepath], "message_count": len(messages)}
+        return {
+            "files": [filepath],
+            "attachments_dir": attachments_dir,
+            "message_count": len(messages),
+            "attachments_exported": exported_files,
+            "attachments_failed": failed_files,
+        }

--- a/python/messages.py
+++ b/python/messages.py
@@ -413,9 +413,53 @@ class MessageExtractor:
             "attachments_failed": failed_files,
         }
 
-    def _export_html(self, messages, chat_id, output_dir):
+    def _html_attachment_markup(self, msg, path_map: dict) -> str:
+        """Build HTML for a message's exported attachments (images + file links)."""
+        parts = []
+        for att in msg.get("attachments") or []:
+            att_id = att.get("attachment_id")
+            rel = path_map.get(att_id) if att_id is not None else None
+            if not rel:
+                continue
+            name = self._attachment_display_name(att) or os.path.basename(rel)
+            mime = (att.get("mime_type") or "").lower()
+            safe_src = html.escape(rel, quote=True)
+            safe_name = html.escape(name)
+            if mime.startswith("image/"):
+                parts.append(
+                    f'<div class="att"><img src="{safe_src}" alt="{safe_name}"></div>'
+                )
+            else:
+                parts.append(
+                    f'<div class="att"><a href="{safe_src}">{safe_name}</a></div>'
+                )
+        return "".join(parts)
+
+    def _html_message_body(self, msg, path_map: dict) -> str:
+        text = (msg.get("text") or "").strip()
+        att_html = self._html_attachment_markup(msg, path_map)
+        if text:
+            body = html.escape(text).replace("\n", "<br>\n")
+            if att_html:
+                return body + att_html
+            return body
+        if att_html:
+            return att_html
+        return "[Attachment]"
+
+    def _export_html(self, messages, chat_id, output_dir, backup=None):
         filename = f"conversation_{chat_id}.html"
         filepath = os.path.join(output_dir, filename)
+
+        attachments_dir = os.path.join(output_dir, "attachments")
+        path_map: dict = {}
+        exported_files = 0
+        failed_files = 0
+        if backup is not None:
+            path_map, exported_files, failed_files = self._export_attachment_files(
+                backup, messages, attachments_dir
+            )
+
         with open(filepath, "w", encoding="utf-8") as f:
             f.write("""<!DOCTYPE html>
 <html><head><meta charset="utf-8"><title>Conversation Export</title>
@@ -426,18 +470,27 @@ body { font-family: -apple-system, sans-serif; max-width: 600px; margin: 0 auto;
 .received { background: #E9E9EB; color: black; float: left; border-bottom-left-radius: 4px; }
 .meta { font-size: 11px; color: #888; clear: both; text-align: center; margin: 12px 0 4px; }
 .sender { font-size: 11px; color: #666; margin-bottom: 2px; }
+.att { margin-top: 8px; }
+.att img { max-width: 100%; border-radius: 8px; display: block; }
+.att a { color: inherit; text-decoration: underline; word-break: break-all; }
 </style></head><body>
 """)
             for msg in messages:
                 css_class = "sent" if msg["is_from_me"] else "received"
-                text = msg["text"] or "[Attachment]"
-                date = msg["date"] or ""
+                body = self._html_message_body(msg, path_map)
+                date = html.escape(msg["date"] or "")
                 f.write(f'<div class="meta">{date}</div>\n')
                 if not msg["is_from_me"]:
-                    f.write(f'<div class="sender">{msg["sender"]}</div>\n')
-                f.write(f'<div class="msg {css_class}">{text}</div>\n')
+                    f.write(f'<div class="sender">{html.escape(msg["sender"])}</div>\n')
+                f.write(f'<div class="msg {css_class}">{body}</div>\n')
             f.write("</body></html>")
-        return {"file": filepath, "message_count": len(messages)}
+        return {
+            "file": filepath,
+            "attachments_dir": attachments_dir,
+            "message_count": len(messages),
+            "attachments_exported": exported_files,
+            "attachments_failed": failed_files,
+        }
 
     # ── Multi-conversation export ────────────────────────────────────────────
 
@@ -531,7 +584,7 @@ body { font-family: -apple-system, sans-serif; max-width: 600px; margin: 0 auto;
         elif fmt == "csv":
             return self._export_merged_csv(all_messages, output_dir, backup=backup)
         elif fmt == "html":
-            return self._export_merged_html(all_messages, output_dir)
+            return self._export_merged_html(all_messages, output_dir, backup=backup)
         else:
             return {"error": f"Unsupported format: {fmt}"}
 
@@ -580,8 +633,18 @@ body { font-family: -apple-system, sans-serif; max-width: 600px; margin: 0 auto;
             "attachments_failed": failed_files,
         }
 
-    def _export_merged_html(self, messages, output_dir):
+    def _export_merged_html(self, messages, output_dir, backup=None):
         filepath = os.path.join(output_dir, "all_conversations.html")
+
+        attachments_dir = os.path.join(output_dir, "attachments")
+        path_map: dict = {}
+        exported_files = 0
+        failed_files = 0
+        if backup is not None:
+            path_map, exported_files, failed_files = self._export_attachment_files(
+                backup, messages, attachments_dir
+            )
+
         with open(filepath, "w", encoding="utf-8") as f:
             f.write("""<!DOCTYPE html>
 <html><head><meta charset="utf-8"><title>Merged Conversations Export</title>
@@ -593,18 +656,30 @@ body { font-family: -apple-system, sans-serif; max-width: 700px; margin: 0 auto;
 .meta { font-size: 11px; color: #888; clear: both; text-align: center; margin: 12px 0 4px; }
 .sender { font-size: 11px; color: #666; margin-bottom: 2px; }
 .conv-label { font-size: 10px; color: #999; font-style: italic; }
+.att { margin-top: 8px; }
+.att img { max-width: 100%; border-radius: 8px; display: block; }
+.att a { color: inherit; text-decoration: underline; word-break: break-all; }
 </style></head><body>
 <h2>Merged Conversations</h2>
 """)
             for msg in messages:
                 css_class = "sent" if msg["is_from_me"] else "received"
-                text = msg["text"] or "[Attachment]"
-                date = msg["date"] or ""
-                conv = msg["_conversation"]
+                body = self._html_message_body(msg, path_map)
+                date = html.escape(msg["date"] or "")
+                conv = html.escape(msg["_conversation"])
                 direction = "to" if msg["is_from_me"] else "from"
-                f.write(f'<div class="meta">{date} <span class="conv-label">({direction} {conv})</span></div>\n')
+                f.write(
+                    f'<div class="meta">{date} '
+                    f'<span class="conv-label">({direction} {conv})</span></div>\n'
+                )
                 if not msg["is_from_me"]:
-                    f.write(f'<div class="sender">{msg["sender"]}</div>\n')
-                f.write(f'<div class="msg {css_class}">{text}</div>\n')
+                    f.write(f'<div class="sender">{html.escape(msg["sender"])}</div>\n')
+                f.write(f'<div class="msg {css_class}">{body}</div>\n')
             f.write("</body></html>")
-        return {"files": [filepath], "message_count": len(messages)}
+        return {
+            "files": [filepath],
+            "attachments_dir": attachments_dir,
+            "message_count": len(messages),
+            "attachments_exported": exported_files,
+            "attachments_failed": failed_files,
+        }

--- a/python/messages.py
+++ b/python/messages.py
@@ -102,6 +102,8 @@ class MessageExtractor:
 
         Returns ``{path, filename, mime_type}`` or ``{error: ...}``.
         """
+        # Re-use the inner extractor's connection helper so we share the
+        # same PRAGMAs / index creation it sets up on first use.
         db_path = self._inner._get_sms_db(backup)
         if not db_path:
             return {"error": "sms.db not found"}
@@ -133,6 +135,8 @@ class MessageExtractor:
 
             mime_type = row["mime_type"]
             filename_lower = (row["filename"] or "").lower()
+            
+            # Infer mime_type from extension if still missing (older backups)
             if not mime_type:
                 _ext_map = {
                     ".jpg": "image/jpeg", ".jpeg": "image/jpeg",
@@ -409,53 +413,9 @@ class MessageExtractor:
             "attachments_failed": failed_files,
         }
 
-    def _html_attachment_markup(self, msg, path_map: dict) -> str:
-        """Build HTML for a message's exported attachments (images + file links)."""
-        parts = []
-        for att in msg.get("attachments") or []:
-            att_id = att.get("attachment_id")
-            rel = path_map.get(att_id) if att_id is not None else None
-            if not rel:
-                continue
-            name = self._attachment_display_name(att) or os.path.basename(rel)
-            mime = (att.get("mime_type") or "").lower()
-            safe_src = html.escape(rel, quote=True)
-            safe_name = html.escape(name)
-            if mime.startswith("image/"):
-                parts.append(
-                    f'<div class="att"><img src="{safe_src}" alt="{safe_name}"></div>'
-                )
-            else:
-                parts.append(
-                    f'<div class="att"><a href="{safe_src}">{safe_name}</a></div>'
-                )
-        return "".join(parts)
-
-    def _html_message_body(self, msg, path_map: dict) -> str:
-        text = (msg.get("text") or "").strip()
-        att_html = self._html_attachment_markup(msg, path_map)
-        if text:
-            body = html.escape(text).replace("\n", "<br>\n")
-            if att_html:
-                return body + att_html
-            return body
-        if att_html:
-            return att_html
-        return "[Attachment]"
-
-    def _export_html(self, messages, chat_id, output_dir, backup=None):
+    def _export_html(self, messages, chat_id, output_dir):
         filename = f"conversation_{chat_id}.html"
         filepath = os.path.join(output_dir, filename)
-
-        attachments_dir = os.path.join(output_dir, "attachments")
-        path_map: dict = {}
-        exported_files = 0
-        failed_files = 0
-        if backup is not None:
-            path_map, exported_files, failed_files = self._export_attachment_files(
-                backup, messages, attachments_dir
-            )
-
         with open(filepath, "w", encoding="utf-8") as f:
             f.write("""<!DOCTYPE html>
 <html><head><meta charset="utf-8"><title>Conversation Export</title>
@@ -466,27 +426,18 @@ body { font-family: -apple-system, sans-serif; max-width: 600px; margin: 0 auto;
 .received { background: #E9E9EB; color: black; float: left; border-bottom-left-radius: 4px; }
 .meta { font-size: 11px; color: #888; clear: both; text-align: center; margin: 12px 0 4px; }
 .sender { font-size: 11px; color: #666; margin-bottom: 2px; }
-.att { margin-top: 8px; }
-.att img { max-width: 100%; border-radius: 8px; display: block; }
-.att a { color: inherit; text-decoration: underline; word-break: break-all; }
 </style></head><body>
 """)
             for msg in messages:
                 css_class = "sent" if msg["is_from_me"] else "received"
-                body = self._html_message_body(msg, path_map)
-                date = html.escape(msg["date"] or "")
+                text = msg["text"] or "[Attachment]"
+                date = msg["date"] or ""
                 f.write(f'<div class="meta">{date}</div>\n')
                 if not msg["is_from_me"]:
-                    f.write(f'<div class="sender">{html.escape(msg["sender"])}</div>\n')
-                f.write(f'<div class="msg {css_class}">{body}</div>\n')
+                    f.write(f'<div class="sender">{msg["sender"]}</div>\n')
+                f.write(f'<div class="msg {css_class}">{text}</div>\n')
             f.write("</body></html>")
-        return {
-            "file": filepath,
-            "attachments_dir": attachments_dir,
-            "message_count": len(messages),
-            "attachments_exported": exported_files,
-            "attachments_failed": failed_files,
-        }
+        return {"file": filepath, "message_count": len(messages)}
 
     # ── Multi-conversation export ────────────────────────────────────────────
 
@@ -580,7 +531,7 @@ body { font-family: -apple-system, sans-serif; max-width: 600px; margin: 0 auto;
         elif fmt == "csv":
             return self._export_merged_csv(all_messages, output_dir, backup=backup)
         elif fmt == "html":
-            return self._export_merged_html(all_messages, output_dir, backup=backup)
+            return self._export_merged_html(all_messages, output_dir)
         else:
             return {"error": f"Unsupported format: {fmt}"}
 
@@ -629,18 +580,8 @@ body { font-family: -apple-system, sans-serif; max-width: 600px; margin: 0 auto;
             "attachments_failed": failed_files,
         }
 
-    def _export_merged_html(self, messages, output_dir, backup=None):
+    def _export_merged_html(self, messages, output_dir):
         filepath = os.path.join(output_dir, "all_conversations.html")
-
-        attachments_dir = os.path.join(output_dir, "attachments")
-        path_map: dict = {}
-        exported_files = 0
-        failed_files = 0
-        if backup is not None:
-            path_map, exported_files, failed_files = self._export_attachment_files(
-                backup, messages, attachments_dir
-            )
-
         with open(filepath, "w", encoding="utf-8") as f:
             f.write("""<!DOCTYPE html>
 <html><head><meta charset="utf-8"><title>Merged Conversations Export</title>
@@ -652,30 +593,18 @@ body { font-family: -apple-system, sans-serif; max-width: 700px; margin: 0 auto;
 .meta { font-size: 11px; color: #888; clear: both; text-align: center; margin: 12px 0 4px; }
 .sender { font-size: 11px; color: #666; margin-bottom: 2px; }
 .conv-label { font-size: 10px; color: #999; font-style: italic; }
-.att { margin-top: 8px; }
-.att img { max-width: 100%; border-radius: 8px; display: block; }
-.att a { color: inherit; text-decoration: underline; word-break: break-all; }
 </style></head><body>
 <h2>Merged Conversations</h2>
 """)
             for msg in messages:
                 css_class = "sent" if msg["is_from_me"] else "received"
-                body = self._html_message_body(msg, path_map)
-                date = html.escape(msg["date"] or "")
-                conv = html.escape(msg["_conversation"])
+                text = msg["text"] or "[Attachment]"
+                date = msg["date"] or ""
+                conv = msg["_conversation"]
                 direction = "to" if msg["is_from_me"] else "from"
-                f.write(
-                    f'<div class="meta">{date} '
-                    f'<span class="conv-label">({direction} {conv})</span></div>\n'
-                )
+                f.write(f'<div class="meta">{date} <span class="conv-label">({direction} {conv})</span></div>\n')
                 if not msg["is_from_me"]:
-                    f.write(f'<div class="sender">{html.escape(msg["sender"])}</div>\n')
-                f.write(f'<div class="msg {css_class}">{body}</div>\n')
+                    f.write(f'<div class="sender">{msg["sender"]}</div>\n')
+                f.write(f'<div class="msg {css_class}">{text}</div>\n')
             f.write("</body></html>")
-        return {
-            "files": [filepath],
-            "attachments_dir": attachments_dir,
-            "message_count": len(messages),
-            "attachments_exported": exported_files,
-            "attachments_failed": failed_files,
-        }
+        return {"files": [filepath], "message_count": len(messages)}

--- a/python/messages.py
+++ b/python/messages.py
@@ -21,7 +21,10 @@ sidecar imports from this module:
 
 import base64
 import csv
+import html
 import os
+import re
+import shutil
 from typing import Optional
 
 from ios_backup_core.extractors.messages import MessageExtractor as _CoreMessageExtractor
@@ -35,11 +38,24 @@ from ios_backup_core.timestamps import (
 
 __all__ = [
     "MessageExtractor",
+    "ATTACHMENT_CSV_COLUMNS",
     "apple_date_to_iso",
     "iso_to_apple_date",
     "parse_attributed_body",
     "APPLE_EPOCH",
     "NANOSECOND_THRESHOLD",
+]
+
+# Companion attachments CSV (one row per attachment; join on Message ID).
+ATTACHMENT_CSV_COLUMNS = [
+    "Message ID",
+    "Date",
+    "Direction",
+    "Sender",
+    "Filename",
+    "Mime Type",
+    "Attachment ID",
+    "Exported Path",
 ]
 
 
@@ -214,11 +230,111 @@ class MessageExtractor:
         if fmt == "txt":
             return self._export_txt(all_messages, chat_id, output_dir)
         elif fmt == "csv":
-            return self._export_csv(all_messages, chat_id, output_dir)
+            return self._export_csv(all_messages, chat_id, output_dir, backup=backup)
         elif fmt == "html":
             return self._export_html(all_messages, chat_id, output_dir)
         else:
             return {"error": f"Unsupported format: {fmt}"}
+
+    def _csv_direction(self, msg) -> str:
+        return "Sent" if msg.get("is_from_me") else "Received"
+
+    def _attachment_display_name(self, attachment: dict) -> str:
+        name = attachment.get("transfer_name") or ""
+        if name:
+            return name
+        path = attachment.get("filename") or ""
+        return os.path.basename(path) if path else ""
+
+    def _safe_attachment_filename(self, name: str) -> str:
+        """Sanitize a display name for use as a single path segment."""
+        base = os.path.basename(name or "") or "attachment"
+        base = re.sub(r"[^\w.\- ()\[\]]+", "_", base, flags=re.UNICODE)
+        base = base.strip(" .") or "attachment"
+        return base
+
+    def _export_attachment_files(
+        self, backup, messages: list, attachments_dir: str
+    ) -> tuple:
+        """Copy attachment binaries into attachments_dir.
+
+        Returns ``(path_map, exported_count, failed_count)`` where path_map
+        maps attachment_id → relative path like ``attachments/…``.
+        """
+        os.makedirs(attachments_dir, exist_ok=True)
+        folder_name = os.path.basename(os.path.normpath(attachments_dir))
+        path_map: dict = {}
+        exported = 0
+        failed = 0
+
+        for msg in messages:
+            message_id = msg.get("message_id")
+            for att in msg.get("attachments") or []:
+                att_id = att.get("attachment_id")
+                if att_id is None:
+                    failed += 1
+                    continue
+                if att_id in path_map:
+                    continue
+
+                resolved = self._resolve_attachment_path(backup, att_id)
+                if "error" in resolved:
+                    failed += 1
+                    continue
+
+                display = (
+                    self._attachment_display_name(att)
+                    or resolved.get("filename")
+                    or "attachment"
+                )
+                safe = self._safe_attachment_filename(display)
+                mid = "unknown" if message_id is None else message_id
+                dest_name = f"{mid}_{att_id}_{safe}"
+                dest_path = os.path.join(attachments_dir, dest_name)
+                try:
+                    shutil.copy2(resolved["path"], dest_path)
+                except OSError:
+                    failed += 1
+                    continue
+
+                path_map[att_id] = f"{folder_name}/{dest_name}"
+                exported += 1
+
+        return path_map, exported, failed
+
+    def _attachment_csv_rows(self, messages: list, path_map: Optional[dict] = None) -> list:
+        """Build attachment CSV data rows (one per attachment)."""
+        path_map = path_map or {}
+        rows = []
+        for msg in messages:
+            message_id = msg.get("message_id")
+            for att in msg.get("attachments") or []:
+                att_id = att.get("attachment_id")
+                exported = ""
+                if att_id is not None:
+                    exported = path_map.get(att_id) or path_map.get(str(att_id)) or ""
+                rows.append([
+                    "" if message_id is None else message_id,
+                    msg.get("date") or "",
+                    self._csv_direction(msg),
+                    msg.get("sender") or "",
+                    self._attachment_display_name(att),
+                    att.get("mime_type") or "",
+                    "" if att_id is None else att_id,
+                    exported,
+                ])
+        return rows
+
+    def _export_attachments_csv(
+        self, messages: list, filepath: str, path_map: Optional[dict] = None
+    ) -> int:
+        """Write companion attachments CSV; always includes header. Returns row count."""
+        rows = self._attachment_csv_rows(messages, path_map=path_map)
+        with open(filepath, "w", newline="", encoding="utf-8-sig") as f:
+            writer = csv.writer(f)
+            writer.writerow(ATTACHMENT_CSV_COLUMNS)
+            writer.writerows(rows)
+        return len(rows)
 
     def _attachment_label(self, msg) -> str:
         """Return a clean text label for a message's attachments."""
@@ -260,7 +376,7 @@ class MessageExtractor:
                 f.write(f"[{date}] {sender}: {text}\n")
         return {"file": filepath, "message_count": len(messages)}
 
-    def _export_csv(self, messages, chat_id, output_dir):
+    def _export_csv(self, messages, chat_id, output_dir, backup=None):
         filename = f"conversation_{chat_id}.csv"
         filepath = os.path.join(output_dir, filename)
         with open(filepath, "w", newline="", encoding="utf-8-sig") as f:
@@ -271,7 +387,27 @@ class MessageExtractor:
                     msg["date"], msg["sender"], self._message_text(msg),
                     msg["is_from_me"], msg["has_attachments"]
                 ])
-        return {"file": filepath, "message_count": len(messages)}
+
+        attachments_dir = os.path.join(output_dir, "attachments")
+        path_map: dict = {}
+        exported_files = 0
+        failed_files = 0
+        if backup is not None:
+            path_map, exported_files, failed_files = self._export_attachment_files(
+                backup, messages, attachments_dir
+            )
+
+        att_path = os.path.join(output_dir, f"conversation_{chat_id}_attachments.csv")
+        att_count = self._export_attachments_csv(messages, att_path, path_map=path_map)
+        return {
+            "file": filepath,
+            "attachments_file": att_path,
+            "attachments_dir": attachments_dir,
+            "message_count": len(messages),
+            "attachment_count": att_count,
+            "attachments_exported": exported_files,
+            "attachments_failed": failed_files,
+        }
 
     def _export_html(self, messages, chat_id, output_dir):
         filename = f"conversation_{chat_id}.html"
@@ -321,6 +457,10 @@ body { font-family: -apple-system, sans-serif; max-width: 600px; margin: 0 auto;
 
         files = []
         total_count = 0
+        total_attachments = 0
+        total_exported = 0
+        total_failed = 0
+        attachments_dir = None
         for chat_id in chat_ids:
             result = self.export_conversation(
                 backup, chat_id, contacts, fmt, output_dir,
@@ -328,8 +468,21 @@ body { font-family: -apple-system, sans-serif; max-width: 600px; margin: 0 auto;
             )
             if "error" not in result:
                 files.append(result["file"])
+                if result.get("attachments_file"):
+                    files.append(result["attachments_file"])
                 total_count += result["message_count"]
-        return {"files": files, "message_count": total_count}
+                total_attachments += result.get("attachment_count") or 0
+                total_exported += result.get("attachments_exported") or 0
+                total_failed += result.get("attachments_failed") or 0
+                attachments_dir = result.get("attachments_dir") or attachments_dir
+        out = {"files": files, "message_count": total_count}
+        if fmt in ("csv", "html"):
+            out["attachment_count"] = total_attachments
+            out["attachments_exported"] = total_exported
+            out["attachments_failed"] = total_failed
+            if attachments_dir:
+                out["attachments_dir"] = attachments_dir
+        return out
 
     def _collect_messages_for_chat(self, backup, chat_id, contacts,
                                    date_from=None, date_to=None, query=None):
@@ -372,7 +525,7 @@ body { font-family: -apple-system, sans-serif; max-width: 600px; margin: 0 auto;
         if fmt == "txt":
             return self._export_merged_txt(all_messages, output_dir)
         elif fmt == "csv":
-            return self._export_merged_csv(all_messages, output_dir)
+            return self._export_merged_csv(all_messages, output_dir, backup=backup)
         elif fmt == "html":
             return self._export_merged_html(all_messages, output_dir)
         else:
@@ -390,7 +543,7 @@ body { font-family: -apple-system, sans-serif; max-width: 600px; margin: 0 auto;
                 f.write(f"[{date}] ({direction} {conv}) {sender}: {text}\n")
         return {"files": [filepath], "message_count": len(messages)}
 
-    def _export_merged_csv(self, messages, output_dir):
+    def _export_merged_csv(self, messages, output_dir, backup=None):
         filepath = os.path.join(output_dir, "all_conversations.csv")
         with open(filepath, "w", newline="", encoding="utf-8-sig") as f:
             writer = csv.writer(f)
@@ -402,7 +555,26 @@ body { font-family: -apple-system, sans-serif; max-width: 600px; margin: 0 auto;
                     msg["sender"], self._message_text(msg),
                     msg["is_from_me"], msg["has_attachments"]
                 ])
-        return {"files": [filepath], "message_count": len(messages)}
+
+        attachments_dir = os.path.join(output_dir, "attachments")
+        path_map: dict = {}
+        exported_files = 0
+        failed_files = 0
+        if backup is not None:
+            path_map, exported_files, failed_files = self._export_attachment_files(
+                backup, messages, attachments_dir
+            )
+
+        att_path = os.path.join(output_dir, "all_conversations_attachments.csv")
+        att_count = self._export_attachments_csv(messages, att_path, path_map=path_map)
+        return {
+            "files": [filepath, att_path],
+            "attachments_dir": attachments_dir,
+            "message_count": len(messages),
+            "attachment_count": att_count,
+            "attachments_exported": exported_files,
+            "attachments_failed": failed_files,
+        }
 
     def _export_merged_html(self, messages, output_dir):
         filepath = os.path.join(output_dir, "all_conversations.html")

--- a/python/messages.py
+++ b/python/messages.py
@@ -81,14 +81,11 @@ class MessageExtractor:
 
     # ── openextract-only: per-id attachment extraction ───────────────────────
 
-    def get_attachment(self, backup, attachment_id: int) -> dict:
-        """Extract and return an attachment file as base64.
+    def _resolve_attachment_path(self, backup, attachment_id: int) -> dict:
+        """Locate an attachment file in the backup (no conversion / encoding).
 
-        ios-backup-core only embeds attachments in get_messages results; this
-        is the standalone per-attachment fetcher openextract's UI uses.
+        Returns ``{path, filename, mime_type}`` or ``{error: ...}``.
         """
-        # Re-use the inner extractor's connection helper so we share the
-        # same PRAGMAs / index creation it sets up on first use.
         db_path = self._inner._get_sms_db(backup)
         if not db_path:
             return {"error": "sms.db not found"}
@@ -118,12 +115,50 @@ class MessageExtractor:
             if not file_path or not os.path.exists(file_path):
                 return {"error": "Attachment file not found in backup"}
 
-            with open(file_path, "rb") as f:
-                raw_data = f.read()
-
             mime_type = row["mime_type"]
             filename_lower = (row["filename"] or "").lower()
-            if mime_type in ("image/heic", "image/heif") or filename_lower.endswith(".heic") or filename_lower.endswith(".heif"):
+            if not mime_type:
+                _ext_map = {
+                    ".jpg": "image/jpeg", ".jpeg": "image/jpeg",
+                    ".png": "image/png", ".gif": "image/gif",
+                    ".heic": "image/heic", ".heif": "image/heif",
+                    ".webp": "image/webp", ".bmp": "image/bmp",
+                }
+                for ext, inferred in _ext_map.items():
+                    if filename_lower.endswith(ext):
+                        mime_type = inferred
+                        break
+
+            return {
+                "path": file_path,
+                "filename": row["transfer_name"] or os.path.basename(row["filename"]),
+                "mime_type": mime_type,
+            }
+        except Exception:
+            raise
+
+    def get_attachment(self, backup, attachment_id: int) -> dict:
+        """Extract and return an attachment file as base64.
+
+        ios-backup-core only embeds attachments in get_messages results; this
+        is the standalone per-attachment fetcher openextract's UI uses.
+        """
+        resolved = self._resolve_attachment_path(backup, attachment_id)
+        if "error" in resolved:
+            return resolved
+
+        try:
+            with open(resolved["path"], "rb") as f:
+                raw_data = f.read()
+
+            mime_type = resolved.get("mime_type")
+            filename_lower = (resolved.get("filename") or "").lower()
+            path_lower = resolved["path"].lower()
+            if (
+                mime_type in ("image/heic", "image/heif")
+                or filename_lower.endswith((".heic", ".heif"))
+                or path_lower.endswith((".heic", ".heif"))
+            ):
                 try:
                     import io
                     import pillow_heif
@@ -137,25 +172,12 @@ class MessageExtractor:
                 except Exception:
                     pass
 
-            # Infer mime_type from extension if still missing (older backups)
-            if not mime_type:
-                _ext_map = {
-                    ".jpg": "image/jpeg", ".jpeg": "image/jpeg",
-                    ".png": "image/png", ".gif": "image/gif",
-                    ".heic": "image/heic", ".heif": "image/heif",
-                    ".webp": "image/webp", ".bmp": "image/bmp",
-                }
-                for ext, inferred in _ext_map.items():
-                    if filename_lower.endswith(ext):
-                        mime_type = inferred
-                        break
-
             data = base64.b64encode(raw_data).decode("ascii")
 
             return {
                 "data": data,
                 "mime_type": mime_type,
-                "filename": row["transfer_name"] or os.path.basename(row["filename"]),
+                "filename": resolved["filename"],
             }
         except Exception:
             raise

--- a/python/tests/test_messages_export_attachments.py
+++ b/python/tests/test_messages_export_attachments.py
@@ -1,0 +1,162 @@
+"""Tests for CSV/HTML attachment export (companion CSV + binary copy)."""
+
+import csv
+import os
+import sys
+import tempfile
+import unittest
+from unittest.mock import MagicMock
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+from messages import ATTACHMENT_CSV_COLUMNS, MessageExtractor  # noqa: E402
+
+
+def _sample_msg(**overrides):
+    base = {
+        "message_id": 42,
+        "text": "hello",
+        "message_type": "text",
+        "date": "2025-12-18T16:32:15+00:00",
+        "is_from_me": True,
+        "sender": "me",
+        "has_attachments": False,
+        "attachments": [],
+    }
+    base.update(overrides)
+    return base
+
+
+class TestCsvAttachmentExport(unittest.TestCase):
+    def setUp(self):
+        self.ext = MessageExtractor.__new__(MessageExtractor)
+        self.ext._inner = MagicMock()
+
+    def test_export_csv_keeps_original_columns_and_writes_companion(self):
+        messages = [
+            _sample_msg(),
+            _sample_msg(
+                message_id=43,
+                is_from_me=False,
+                sender="Kevin",
+                text="",
+                has_attachments=True,
+                attachments=[{
+                    "attachment_id": 9,
+                    "transfer_name": "clip.mp4",
+                    "mime_type": "video/mp4",
+                }],
+            ),
+        ]
+        with tempfile.TemporaryDirectory() as tmp:
+            src = os.path.join(tmp, "src.bin")
+            with open(src, "wb") as f:
+                f.write(b"video-bytes")
+            self.ext._resolve_attachment_path = MagicMock(return_value={
+                "path": src,
+                "filename": "clip.mp4",
+                "mime_type": "video/mp4",
+            })
+            out = os.path.join(tmp, "out")
+            os.makedirs(out)
+            result = self.ext._export_csv(messages, chat_id=1654, output_dir=out, backup=object())
+
+            with open(result["file"], newline="", encoding="utf-8-sig") as f:
+                rows = list(csv.reader(f))
+            self.assertEqual(
+                rows[0],
+                ["Date", "Sender", "Text", "Is From Me", "Has Attachments"],
+            )
+            self.assertEqual(result["attachments_exported"], 1)
+            dest = os.path.join(out, "attachments", "43_9_clip.mp4")
+            self.assertTrue(os.path.exists(dest))
+
+            with open(result["attachments_file"], newline="", encoding="utf-8-sig") as f:
+                att_rows = list(csv.reader(f))
+            self.assertEqual(att_rows[0], ATTACHMENT_CSV_COLUMNS)
+            path_col = ATTACHMENT_CSV_COLUMNS.index("Exported Path")
+            self.assertEqual(att_rows[1][path_col], "attachments/43_9_clip.mp4")
+
+    def test_export_csv_missing_attachment_leaves_path_empty(self):
+        self.ext._resolve_attachment_path = MagicMock(
+            return_value={"error": "Attachment file not found in backup"}
+        )
+        messages = [
+            _sample_msg(
+                message_id=43,
+                has_attachments=True,
+                attachments=[{
+                    "attachment_id": 9,
+                    "transfer_name": "missing.mp4",
+                    "mime_type": "video/mp4",
+                }],
+            ),
+        ]
+        with tempfile.TemporaryDirectory() as tmp:
+            result = self.ext._export_csv(messages, chat_id=1, output_dir=tmp, backup=object())
+            self.assertEqual(result["attachments_exported"], 0)
+            self.assertEqual(result["attachments_failed"], 1)
+            with open(result["attachments_file"], newline="", encoding="utf-8-sig") as f:
+                att_rows = list(csv.reader(f))
+            path_col = ATTACHMENT_CSV_COLUMNS.index("Exported Path")
+            self.assertEqual(att_rows[1][path_col], "")
+
+
+class TestHtmlAttachmentExport(unittest.TestCase):
+    def setUp(self):
+        self.ext = MessageExtractor.__new__(MessageExtractor)
+        self.ext._inner = MagicMock()
+
+    def test_export_html_embeds_image_and_links_file(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            img_src = os.path.join(tmp, "photo.jpg")
+            file_src = os.path.join(tmp, "doc.pdf")
+            with open(img_src, "wb") as f:
+                f.write(b"jpeg")
+            with open(file_src, "wb") as f:
+                f.write(b"%PDF")
+
+            def resolve(_backup, att_id):
+                if att_id == 1:
+                    return {"path": img_src, "filename": "photo.jpg", "mime_type": "image/jpeg"}
+                if att_id == 2:
+                    return {"path": file_src, "filename": "doc.pdf", "mime_type": "application/pdf"}
+                return {"error": "missing"}
+
+            self.ext._resolve_attachment_path = MagicMock(side_effect=resolve)
+            messages = [
+                _sample_msg(
+                    message_id=10,
+                    text="see this",
+                    has_attachments=True,
+                    attachments=[{
+                        "attachment_id": 1,
+                        "transfer_name": "photo.jpg",
+                        "mime_type": "image/jpeg",
+                    }],
+                ),
+                _sample_msg(
+                    message_id=11,
+                    text="",
+                    is_from_me=False,
+                    sender="Kevin",
+                    has_attachments=True,
+                    attachments=[{
+                        "attachment_id": 2,
+                        "transfer_name": "doc.pdf",
+                        "mime_type": "application/pdf",
+                    }],
+                ),
+            ]
+            out = os.path.join(tmp, "out")
+            os.makedirs(out)
+            result = self.ext._export_html(messages, chat_id=7, output_dir=out, backup=object())
+            with open(result["file"], encoding="utf-8") as f:
+                content = f.read()
+            self.assertIn('src="attachments/10_1_photo.jpg"', content)
+            self.assertIn('href="attachments/11_2_doc.pdf"', content)
+            self.assertIn("doc.pdf", content)
+            self.assertEqual(result["attachments_exported"], 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/tests/test_messages_export_attachments.py
+++ b/python/tests/test_messages_export_attachments.py
@@ -1,4 +1,10 @@
-"""Tests for CSV/HTML attachment export (companion CSV + binary copy)."""
+"""
+Tests for messages.py — CSV/HTML attachment export
+
+Covers companion attachments CSV, binary copy into attachments/, and HTML
+img/link references.  Backup file resolution is mocked via
+``_resolve_attachment_path`` so these tests never need a real iPhone backup.
+"""
 
 import csv
 import os
@@ -7,11 +13,18 @@ import tempfile
 import unittest
 from unittest.mock import MagicMock
 
+# Allow ``from messages import …`` whether pytest is launched from the repo
+# root or from python/ (same pattern as inserting "python" on sys.path).
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 from messages import ATTACHMENT_CSV_COLUMNS, MessageExtractor  # noqa: E402
 
 
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
 def _sample_msg(**overrides):
+    """Minimal message dict shaped like ios_backup_core get_messages output."""
     base = {
         "message_id": 42,
         "text": "hello",
@@ -26,12 +39,26 @@ def _sample_msg(**overrides):
     return base
 
 
+def _make_extractor():
+    """MessageExtractor without running __init__ (avoids core extractor setup)."""
+    ext = MessageExtractor.__new__(MessageExtractor)
+    ext._inner = MagicMock()
+    return ext
+
+
+# ---------------------------------------------------------------------------
+# CSV export
+# ---------------------------------------------------------------------------
+
 class TestCsvAttachmentExport(unittest.TestCase):
+    """Sidecar CSV export: original message columns + companion attachments file."""
+
     def setUp(self):
-        self.ext = MessageExtractor.__new__(MessageExtractor)
-        self.ext._inner = MagicMock()
+        self.ext = _make_extractor()
 
     def test_export_csv_keeps_original_columns_and_writes_companion(self):
+        # Message CSV must stay Date/Sender/Text/Is From Me/Has Attachments;
+        # attachment details go in the companion CSV and on disk.
         messages = [
             _sample_msg(),
             _sample_msg(
@@ -48,6 +75,7 @@ class TestCsvAttachmentExport(unittest.TestCase):
             ),
         ]
         with tempfile.TemporaryDirectory() as tmp:
+            # Fake backup payload that copy2 will read.
             src = os.path.join(tmp, "src.bin")
             with open(src, "wb") as f:
                 f.write(b"video-bytes")
@@ -58,7 +86,10 @@ class TestCsvAttachmentExport(unittest.TestCase):
             })
             out = os.path.join(tmp, "out")
             os.makedirs(out)
-            result = self.ext._export_csv(messages, chat_id=1654, output_dir=out, backup=object())
+            # backup=object() is enough: we stub resolve, so no real SMS DB.
+            result = self.ext._export_csv(
+                messages, chat_id=1654, output_dir=out, backup=object()
+            )
 
             with open(result["file"], newline="", encoding="utf-8-sig") as f:
                 rows = list(csv.reader(f))
@@ -77,6 +108,8 @@ class TestCsvAttachmentExport(unittest.TestCase):
             self.assertEqual(att_rows[1][path_col], "attachments/43_9_clip.mp4")
 
     def test_export_csv_missing_attachment_leaves_path_empty(self):
+        # Missing files must not fail the whole export; companion row stays,
+        # Exported Path is blank, and attachments_failed is incremented.
         self.ext._resolve_attachment_path = MagicMock(
             return_value={"error": "Attachment file not found in backup"}
         )
@@ -92,7 +125,9 @@ class TestCsvAttachmentExport(unittest.TestCase):
             ),
         ]
         with tempfile.TemporaryDirectory() as tmp:
-            result = self.ext._export_csv(messages, chat_id=1, output_dir=tmp, backup=object())
+            result = self.ext._export_csv(
+                messages, chat_id=1, output_dir=tmp, backup=object()
+            )
             self.assertEqual(result["attachments_exported"], 0)
             self.assertEqual(result["attachments_failed"], 1)
             with open(result["attachments_file"], newline="", encoding="utf-8-sig") as f:
@@ -101,12 +136,18 @@ class TestCsvAttachmentExport(unittest.TestCase):
             self.assertEqual(att_rows[1][path_col], "")
 
 
+# ---------------------------------------------------------------------------
+# HTML export
+# ---------------------------------------------------------------------------
+
 class TestHtmlAttachmentExport(unittest.TestCase):
+    """HTML export: copy files and reference them from message bubbles."""
+
     def setUp(self):
-        self.ext = MessageExtractor.__new__(MessageExtractor)
-        self.ext._inner = MagicMock()
+        self.ext = _make_extractor()
 
     def test_export_html_embeds_image_and_links_file(self):
+        # Images become <img src="attachments/…">; other mime types become <a href>.
         with tempfile.TemporaryDirectory() as tmp:
             img_src = os.path.join(tmp, "photo.jpg")
             file_src = os.path.join(tmp, "doc.pdf")
@@ -117,9 +158,17 @@ class TestHtmlAttachmentExport(unittest.TestCase):
 
             def resolve(_backup, att_id):
                 if att_id == 1:
-                    return {"path": img_src, "filename": "photo.jpg", "mime_type": "image/jpeg"}
+                    return {
+                        "path": img_src,
+                        "filename": "photo.jpg",
+                        "mime_type": "image/jpeg",
+                    }
                 if att_id == 2:
-                    return {"path": file_src, "filename": "doc.pdf", "mime_type": "application/pdf"}
+                    return {
+                        "path": file_src,
+                        "filename": "doc.pdf",
+                        "mime_type": "application/pdf",
+                    }
                 return {"error": "missing"}
 
             self.ext._resolve_attachment_path = MagicMock(side_effect=resolve)
@@ -149,7 +198,9 @@ class TestHtmlAttachmentExport(unittest.TestCase):
             ]
             out = os.path.join(tmp, "out")
             os.makedirs(out)
-            result = self.ext._export_html(messages, chat_id=7, output_dir=out, backup=object())
+            result = self.ext._export_html(
+                messages, chat_id=7, output_dir=out, backup=object()
+            )
             with open(result["file"], encoding="utf-8") as f:
                 content = f.read()
             self.assertIn('src="attachments/10_1_photo.jpg"', content)


### PR DESCRIPTION
## Summary

When you export a conversation as CSV or HTML from the Messages UI, OpenExtract now also pulls attachment files out of the backup into an attachments/ folder next to the export. CSV gets a companion index file; HTML embeds or links those files in the chat bubbles.

The companion CSV file was chosen because multiple attachments can be sent in a single message. Duplicating a sent entry in the CSV for each attachment with the same metadata including the timestamp would be confusing. If a message has no attachments then the companion CSV is excluded.

*Note*: If the sidecar CSV is not acceptable, then perhaps we could embed json data into the attachment field, to keep a single csv.

### CSV formats

#### Messages CSV (single conversation)
| Date | Sender | Text | Is From Me | Has Attachments |
|------|--------|------|------------|-----------------|

#### Messages CSV (merged)
| Date | Conversation | Direction | Sender | Text | Is From Me | Has Attachments |
|------|--------------|-----------|--------|------|------------|-----------------|

#### Attachments CSV (companion)
| Message ID | Date | Direction | Sender | Filename | Mime Type | Attachment ID | Exported Path |
|------------|------|-----------|--------|----------|-----------|---------------|---------------|


Sample output files:
```
export folder/
  conversation_1654.csv                 # same as before
  conversation_1654_attachments.csv     # one row per attachment
  conversation_1654.html                # bubbles + img/links (if HTML)
  attachments/
    89733_4455_Resume.pdf               # {message_id}_{attachment_id}_{name}
```

## Related issue

<!-- e.g. Closes #123 -->

## Change type

- [ ] Bug fix (behavior change, existing feature)
- [x] New feature
- [ ] Performance
- [ ] Refactor (no functional change)
- [ ] Docs / build / CI

## Test plan

Unit tests + manual testing.

<details>
<summary>Manual testing</summary>

Exporting all the different permutations on either the left panel using selection or the right side for the individual contact yields the correct result. .csv, .html and individual / combined were all tested.

```
user@machine:~$ tree test_export/
test_export/
├── message-panel-export-csv
│   ├── attachments
│   │   ├── 14771_1469_IMG_6276.jpg
│   │   ├── 18160_991_IMG_5554.JPG
│   │   ├── 30485_243_image000000.jpg
│   │   ├── 31127_378_image000000.jpg
│   │   ├── 87354_4324_IMG_2297.JPG
│   │   ├── 94401_4765_IMG_2091.jpeg
│   │   ├── 94401_4766_IMG_2090.jpeg
│   │   ├── 94402_4767_IMG_2092.jpeg
│   │   └── 94402_4768_IMG_2093.jpeg
│   ├── conversation_281_attachments.csv
│   └── conversation_281.csv
├── message-panel-export-html
│   ├── attachments
│   │   ├── 14771_1469_IMG_6276.jpg
│   │   ├── 18160_991_IMG_5554.JPG
│   │   ├── 30485_243_image000000.jpg
│   │   ├── 31127_378_image000000.jpg
│   │   ├── 87354_4324_IMG_2297.JPG
│   │   ├── 94401_4765_IMG_2091.jpeg
│   │   ├── 94401_4766_IMG_2090.jpeg
│   │   ├── 94402_4767_IMG_2092.jpeg
│   │   └── 94402_4768_IMG_2093.jpeg
│   └── conversation_281.html
├── select-export-csv-many
│   ├── separate-files
│   │   ├── attachments
│   │   │   ├── 14771_1469_IMG_6276.jpg
│   │   │   ├── 18160_991_IMG_5554.JPG
│   │   │   ├── 30485_243_image000000.jpg
│   │   │   ├── 31127_378_image000000.jpg
│   │   │   ├── 68424_3276_IMG_7002.heic
│   │   │   ├── 87354_4324_IMG_2297.JPG
│   │   │   ├── 94401_4765_IMG_2091.jpeg
│   │   │   ├── 94401_4766_IMG_2090.jpeg
│   │   │   ├── 94402_4767_IMG_2092.jpeg
│   │   │   └── 94402_4768_IMG_2093.jpeg
│   │   ├── conversation_1237_attachments.csv
│   │   ├── conversation_1237.csv
│   │   ├── conversation_281_attachments.csv
│   │   └── conversation_281.csv
│   └── single-file
│       ├── all_conversations_attachments.csv
│       ├── all_conversations.csv
│       └── attachments
│           ├── 14771_1469_IMG_6276.jpg
│           ├── 18160_991_IMG_5554.JPG
│           ├── 30485_243_image000000.jpg
│           ├── 31127_378_image000000.jpg
│           ├── 68424_3276_IMG_7002.heic
│           ├── 87354_4324_IMG_2297.JPG
│           ├── 94401_4765_IMG_2091.jpeg
│           ├── 94401_4766_IMG_2090.jpeg
│           ├── 94402_4767_IMG_2092.jpeg
│           └── 94402_4768_IMG_2093.jpeg
├── select-export-csv-single
│   ├── separate-files
│   │   ├── attachments
│   │   │   ├── 14771_1469_IMG_6276.jpg
│   │   │   ├── 18160_991_IMG_5554.JPG
│   │   │   ├── 30485_243_image000000.jpg
│   │   │   ├── 31127_378_image000000.jpg
│   │   │   ├── 87354_4324_IMG_2297.JPG
│   │   │   ├── 94401_4765_IMG_2091.jpeg
│   │   │   ├── 94401_4766_IMG_2090.jpeg
│   │   │   ├── 94402_4767_IMG_2092.jpeg
│   │   │   └── 94402_4768_IMG_2093.jpeg
│   │   ├── conversation_281_attachments.csv
│   │   └── conversation_281.csv
│   └── single-file
│       ├── all_conversations_attachments.csv
│       ├── all_conversations.csv
│       └── attachments
│           ├── 14771_1469_IMG_6276.jpg
│           ├── 18160_991_IMG_5554.JPG
│           ├── 30485_243_image000000.jpg
│           ├── 31127_378_image000000.jpg
│           ├── 87354_4324_IMG_2297.JPG
│           ├── 94401_4765_IMG_2091.jpeg
│           ├── 94401_4766_IMG_2090.jpeg
│           ├── 94402_4767_IMG_2092.jpeg
│           └── 94402_4768_IMG_2093.jpeg
├── select-export-html-many
│   ├── separate-files
│   │   ├── attachments
│   │   │   ├── 14771_1469_IMG_6276.jpg
│   │   │   ├── 18160_991_IMG_5554.JPG
│   │   │   ├── 30485_243_image000000.jpg
│   │   │   ├── 31127_378_image000000.jpg
│   │   │   ├── 68424_3276_IMG_7002.heic
│   │   │   ├── 87354_4324_IMG_2297.JPG
│   │   │   ├── 94401_4765_IMG_2091.jpeg
│   │   │   ├── 94401_4766_IMG_2090.jpeg
│   │   │   ├── 94402_4767_IMG_2092.jpeg
│   │   │   └── 94402_4768_IMG_2093.jpeg
│   │   ├── conversation_1237.html
│   │   └── conversation_281.html
│   └── single-file
│       ├── all_conversations.html
│       └── attachments
│           ├── 14771_1469_IMG_6276.jpg
│           ├── 18160_991_IMG_5554.JPG
│           ├── 30485_243_image000000.jpg
│           ├── 31127_378_image000000.jpg
│           ├── 68424_3276_IMG_7002.heic
│           ├── 87354_4324_IMG_2297.JPG
│           ├── 94401_4765_IMG_2091.jpeg
│           ├── 94401_4766_IMG_2090.jpeg
│           ├── 94402_4767_IMG_2092.jpeg
│           └── 94402_4768_IMG_2093.jpeg
└── select-export-html-single
    ├── separate-files
    │   ├── attachments
    │   │   ├── 14771_1469_IMG_6276.jpg
    │   │   ├── 18160_991_IMG_5554.JPG
    │   │   ├── 30485_243_image000000.jpg
    │   │   ├── 31127_378_image000000.jpg
    │   │   ├── 87354_4324_IMG_2297.JPG
    │   │   ├── 94401_4765_IMG_2091.jpeg
    │   │   ├── 94401_4766_IMG_2090.jpeg
    │   │   ├── 94402_4767_IMG_2092.jpeg
    │   │   └── 94402_4768_IMG_2093.jpeg
    │   └── conversation_281.html
    └── single-file
        ├── all_conversations.html
        └── attachments
            ├── 14771_1469_IMG_6276.jpg
            ├── 18160_991_IMG_5554.JPG
            ├── 30485_243_image000000.jpg
            ├── 31127_378_image000000.jpg
            ├── 87354_4324_IMG_2297.JPG
            ├── 94401_4765_IMG_2091.jpeg
            ├── 94401_4766_IMG_2090.jpeg
            ├── 94402_4767_IMG_2092.jpeg
            └── 94402_4768_IMG_2093.jpeg

25 directories, 112 files

```

</details>

## Screenshots (if UI)

<!-- Drag-drop into the text area -->

## Checklist

- [x] I've run the existing tests locally.
- [x] I've added tests for new behavior (or explained why tests don't apply).
- [ ] I've updated CHANGELOG.md if this is user-visible.
- [x] I've redacted any personal data from fixtures, screenshots, and logs.
