### PR TITLE
Issues 82: Fix message sort order

### DIFF
--- a/python/messages.py
+++ b/python/messages.py
@@ -162,6 +162,19 @@ class MessageExtractor:
 
     # ── openextract-only: conversation export to disk ────────────────────────
 
+    @staticmethod
+    def _sort_messages_chronologically(messages: list) -> list:
+        """Oldest-first order for exports.
+
+        ``get_messages`` returns pages of the *newest* remaining rows (each page
+        is chronological within itself). Concatenating those pages without a
+        final sort puts newer days before older ones — see GitHub issue #82.
+        """
+        return sorted(
+            messages,
+            key=lambda m: (m.get("date") or "", m.get("message_id") or 0),
+        )
+
     def export_conversation(self, backup, chat_id: int, contacts: dict,
                             fmt: str, output_dir: str,
                             date_from: Optional[str] = None,
@@ -188,6 +201,8 @@ class MessageExtractor:
                 if offset + 500 >= batch["total"]:
                     break
                 offset += 500
+
+        all_messages = self._sort_messages_chronologically(all_messages)
 
         if fmt == "txt":
             return self._export_txt(all_messages, chat_id, output_dir)
@@ -317,7 +332,7 @@ body { font-family: -apple-system, sans-serif; max-width: 600px; margin: 0 auto;
                 backup, query, contacts, chat_id,
                 date_from=date_from, date_to=date_to, limit=100000
             )
-            return result["results"]
+            all_messages = result["results"]
         else:
             all_messages = []
             offset = 0
@@ -330,7 +345,7 @@ body { font-family: -apple-system, sans-serif; max-width: 600px; margin: 0 auto;
                 if offset + 500 >= batch["total"]:
                     break
                 offset += 500
-            return all_messages
+        return self._sort_messages_chronologically(all_messages)
 
     def _export_merged(self, backup, chat_ids, conversation_names, contacts,
                        fmt, output_dir, date_from=None, date_to=None, query=None):

--- a/python/tests/test_export_message_order.py
+++ b/python/tests/test_export_message_order.py
@@ -1,0 +1,99 @@
+"""
+Tests for export message ordering (GitHub issue #82).
+
+get_messages returns newest-first *pages*. Concatenating those pages without
+sorting puts newer days before older ones in TXT/CSV/HTML exports.
+"""
+
+import os
+import sys
+import tempfile
+import unittest
+from unittest.mock import MagicMock
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+from messages import MessageExtractor  # noqa: E402
+
+
+def _msg(message_id: int, date: str, text: str = "") -> dict:
+    return {
+        "message_id": message_id,
+        "date": date,
+        "text": text or f"msg-{message_id}",
+        "sender": "me",
+        "is_from_me": True,
+        "has_attachments": False,
+        "attachments": [],
+    }
+
+
+class TestExportMessageOrder(unittest.TestCase):
+    """Single-conversation export must be oldest → newest across all pages."""
+
+    def setUp(self):
+        self.ext = MessageExtractor.__new__(MessageExtractor)
+        self.ext._inner = MagicMock()
+
+    def test_sort_messages_chronologically(self):
+        # Newer page chunk first (as if concatenated from get_messages pages).
+        messages = [
+            _msg(3, "2026-01-02T10:00:00+00:00"),
+            _msg(4, "2026-01-02T11:00:00+00:00"),
+            _msg(1, "2026-01-01T09:00:00+00:00"),
+            _msg(2, "2026-01-01T10:00:00+00:00"),
+        ]
+        ordered = MessageExtractor._sort_messages_chronologically(messages)
+        self.assertEqual(
+            [m["message_id"] for m in ordered],
+            [1, 2, 3, 4],
+        )
+
+    def test_export_html_is_chronological_across_pages(self):
+        # Simulate two get_messages pages: newest day first, then older day.
+        page_new = [
+            _msg(3, "2026-01-02T10:00:00+00:00", "day2-a"),
+            _msg(4, "2026-01-02T11:00:00+00:00", "day2-b"),
+        ]
+        page_old = [
+            _msg(1, "2026-01-01T09:00:00+00:00", "day1-a"),
+            _msg(2, "2026-01-01T10:00:00+00:00", "day1-b"),
+        ]
+
+        def fake_get_messages(backup, chat_id, contacts, offset=0, limit=500,
+                              date_from=None, date_to=None):
+            # Mimic real pagination: offset 0 = newest window, offset 500 = older.
+            # total > 500 so export_conversation fetches both pages.
+            if offset == 0:
+                batch = page_new
+            elif offset == 500:
+                batch = page_old
+            else:
+                batch = []
+            return {
+                "messages": batch,
+                "total": 1000,
+                "next_offset": offset + limit,
+            }
+
+        self.ext.get_messages = fake_get_messages
+        self.ext.search_messages = MagicMock()
+
+        with tempfile.TemporaryDirectory() as tmp:
+            result = self.ext.export_conversation(
+                backup=object(),
+                chat_id=1,
+                contacts={},
+                fmt="html",
+                output_dir=tmp,
+            )
+            with open(result["file"], encoding="utf-8") as f:
+                html = f.read()
+
+        # Day 1 content must appear before day 2 in the exported HTML.
+        self.assertLess(html.index("day1-a"), html.index("day1-b"))
+        self.assertLess(html.index("day1-b"), html.index("day2-a"))
+        self.assertLess(html.index("day2-a"), html.index("day2-b"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Exported conversations (TXT, CSV, HTML) showed each day in order, but the days themselves were newest-first, which broke the chat message ordering.

**Cause**: Messages are loaded in pages that start with the most recent ones. Export was writing those pages one after another without reordering the full list.

**Fix**: After all messages are collected, sort them oldest to newest before writing the export file.

<!--
Thanks for contributing! A few asks to make review smooth:

1. Link any related issue (e.g. "Closes #123").
2. If this is a user-visible change, note it in CHANGELOG.md under Unreleased.
3. For new parsing logic or backup-format handling, include a test with
   a sanitized fixture (no real user data).
-->

## Summary

<!-- What does this PR change and why? Short is fine. -->

## Related issue

<!-- e.g. Closes #123 -->

## Change type

- [x] Bug fix (behavior change, existing feature) - [Issue 82](https://github.com/charleswest775/openextract/issues/82)
- [ ] New feature
- [ ] Performance
- [ ] Refactor (no functional change)
- [ ] Docs / build / CI

## Test plan

<!-- How did you verify the change? Include platform(s). -->

## Screenshots (if UI)

<!-- Drag-drop into the text area -->

## Checklist

- [x] I've run the existing tests locally.
- [ ] I've added tests for new behavior (or explained why tests don't apply).
- [ ] I've updated CHANGELOG.md if this is user-visible.
- [ ] I've redacted any personal data from fixtures, screenshots, and logs.

@charleswest775 